### PR TITLE
[#003] plot_BvsA_as_distribution(dist_rel=bool dist_sample_min=int)

### DIFF
--- a/datastock/_class3.py
+++ b/datastock/_class3.py
@@ -84,6 +84,8 @@ class DataStock3(DataStock2):
         dist_cmap=None,
         dist_min=None,
         dist_max=None,
+        dist_sample_min=None,
+        dist_rel=None,
         # customization of interactivity
         ind0=None,
         nmax=None,
@@ -123,6 +125,8 @@ class DataStock3(DataStock2):
             dist_cmap=dist_cmap,
             dist_min=dist_min,
             dist_max=dist_max,
+            dist_sample_min=dist_sample_min,
+            dist_rel=dist_rel,
             # customization of interactivity
             ind0=ind0,
             nmax=nmax,


### PR DESCRIPTION
Main changes:
--------------------

`plot_BvsA_as_distribution() `now allows to set:
* `dist_rel = True / False`: if True the 2d distribution is plotted as a real distribution function (normalized to its integral)
* `dist_ample_min = int` (set to 1 by default), lower limit for which a distribution element can be considered valid, any lower value will be set to nan.

Examples:
--------------

```
In [1]: nt0 = 1000; t0 = np.linspace(0, 10, nt0); nx = 100; x = np.linspace(0, 10, nx); x0 = np.sin(t0)[:, None] * np.exp(-(x-x.mean())**2/ 0.1)[None, :]; y0 = x0 + np.random.normal(scale=0.1, size=(nt0, n
    ...: x));

In [2]: st = ds.DataStock(); st.add_ref(key='t0', size=nt0); st.add_ref(key='x', size=nx); st.add_data(key='t0', data=t0); st.add_data(key='x0', data=x0); st.add_data(key='y0', data=y0);

In [3]: st
Out[3]: 
ref key  size  nb. data  nb. data monot.
-------  ----  --------  ---------------
t0       1000  3         1              
x        100   2         0              

data key  shape        ref          monot           units  dim      quant    name     source 
--------  -----------  -----------  --------------  -----  -------  -------  -------  -------
t0        (1000,)      ('t0',)      (True,)         a.u.   unknown  unknown  unknown  unknown
x0        (1000, 100)  ('t0', 'x')  (False, False)  a.u.   unknown  unknown  unknown  unknown
y0        (1000, 100)  ('t0', 'x')  (False, False)  a.u.   unknown  unknown  unknown  unknown

In [4]: dax = st.plot_BvsA_as_distribution(keyA='x0', keyB='y0', dist_rel=True, dist_sample_min=3)
```


![image](https://user-images.githubusercontent.com/5929562/156762894-9f693e4f-de41-4b7c-9319-260204641677.png)