### PR TITLE
Issue026 plot bool

### DIFF
--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -676,6 +676,20 @@ def _check_data(data=None, key=None, max_ndim=None):
     if c0_array:
         if data.dtype.type == np.str_:
             monotonous = tuple([False for ii in data.shape])
+        elif scpsp.issparse(data):
+            monot = np.all(np.isfinite(data.data))
+            data_temp = data.toarray()
+            monotonous = tuple([
+                bool(
+                    monot
+                    and (
+                        np.all(np.diff(data_temp, axis=aa) > 0.)
+                        or np.all(np.diff(data_temp, axis=aa) < 0.)
+                    )
+                )
+                for aa in range(data.ndim)
+            ])
+            del data_temp
         else:
             monot = np.all(np.isfinite(data))
             monotonous = tuple([

--- a/datastock/_class2.py
+++ b/datastock/_class2.py
@@ -4,6 +4,7 @@ import warnings
 
 
 import numpy as np
+import scipy.sparse as scpsparse
 import matplotlib.pyplot as plt
 
 
@@ -951,6 +952,11 @@ class DataStock2(DataStock1):
             cdy = self._ddata[cur_datay]['data']
             dx = np.diff(ax.get_xlim())
             dy = np.diff(ax.get_ylim())
+
+            if scpsparse.issparse(cdx) or scpsparse.issparse(cdy):
+                msg = "No handling of pts selection for sparse data yet!"
+                raise Exception(msg)
+
             dist = ((cdx - event.xdata)/dx)**2 + ((cdy - event.ydata)/dy)**2
             if dist.ndim == 1:
                 ix = np.nanargmin(dist)

--- a/datastock/_class2.py
+++ b/datastock/_class2.py
@@ -841,13 +841,15 @@ class DataStock2(DataStock1):
         # --- Redraw all objects (due to background restore) --- 25 ms
         for k0, v0 in self._dobj['mobile'].items():
             v0['handle'].set_visible(v0['visible'])
-            try:
-                self._dobj['axes'][v0['axes']]['handle'].draw_artist(v0['handle'])
-            except Exception:
-                print(0, k0)        # DB
-                print(1, v0['axes'])    # DB
-                print(2, self._dobj['axes'][v0['axes']]['handle'])  # DB
-                print(3, v0['handle'])  # DB
+            # try:
+            self._dobj['axes'][v0['axes']]['handle'].draw_artist(v0['handle'])
+            # except Exception as err:
+                # print(0, k0)        # DB
+                # print(1, v0['axes'])    # DB
+                # print(2, self._dobj['axes'][v0['axes']]['handle'])  # DB
+                # print(3, v0['handle'])  # DB
+                # print(err)
+                # print()
 
         # ---- blit axes ------ 5 ms
         for aa in lax:

--- a/datastock/_class2_interactivity.py
+++ b/datastock/_class2_interactivity.py
@@ -1,6 +1,7 @@
 
 
 import numpy as np
+import scipy.sparse as scpsparse
 
 
 _INCREMENTS = [1, 10]
@@ -383,6 +384,17 @@ def _update_mobile(k0=None, dmobile=None, dref=None, ddata=None):
         if c0:
             dmobile[k0]['func_set_data'][0](*iref)
 
+        elif scpsparse.issparse(ddata[dmobile[k0]['data'][0]]['data']):
+            if ddata[dmobile[k0]['data'][0]]['data'].ndim <= 2:
+                dmobile[k0]['func_set_data'][0](
+                    ddata[dmobile[k0]['data'][0]]['data'][
+                        dmobile[k0]['func_slice'][0](*iref)
+                    ].data
+                )
+            else:
+                msg = "Sparse data of dim > 2: not handled yet"
+                raise Exception(msg)
+
         else:
             dmobile[k0]['func_set_data'][0](
                 ddata[dmobile[k0]['data'][0]]['data'][
@@ -398,6 +410,18 @@ def _update_mobile(k0=None, dmobile=None, dref=None, ddata=None):
             )
             if c0:
                 dmobile[k0]['func_set_data'][ii](iref[ii])
+
+            elif scpsparse.issparse(ddata[dmobile[k0]['data'][ii]]['data']):
+                if ddata[dmobile[k0]['data'][ii]]['data'].ndim <= 2:
+                    dmobile[k0]['func_set_data'][ii](
+                        ddata[dmobile[k0]['data'][ii]]['data'][
+                            dmobile[k0]['func_slice'][ii](iref[ii])
+                        ].data
+                    )
+                else:
+                    msg = "Sparse data of dim > 2: not handled yet"
+                    raise Exception(msg)
+
             else:
                 dmobile[k0]['func_set_data'][ii](
                     ddata[dmobile[k0]['data'][ii]]['data'][

--- a/datastock/_plot_BvsA_as_distribution.py
+++ b/datastock/_plot_BvsA_as_distribution.py
@@ -8,6 +8,7 @@
 
 # Common
 import numpy as np
+import scipy.sparse as scpsparse
 import scipy.stats as scpstats
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
@@ -504,7 +505,10 @@ def _compute_dist(
     Bgridplot = np.tile(Bgridplot, (nBbin-1, 1))
     extent = (Amin, Amax, Bmin, Bmax)
 
+    # iok
     iok = np.isfinite(dataA) & np.isfinite(dataB)
+
+    # databin
     databin = scpstats.binned_statistic_2d(
         dataA[iok],
         dataB[iok],

--- a/datastock/_plot_BvsA_as_distribution_check.py
+++ b/datastock/_plot_BvsA_as_distribution_check.py
@@ -1,6 +1,7 @@
 
 
 import numpy as np
+import scipy.sparse as scpsparse
 import matplotlib.colors as mcolors
 
 
@@ -327,13 +328,13 @@ def _plot_BvsA_check(
 
     # Amin, Amax, Bmin, Bmax
     if Amin is None:
-        Amin = np.nanmin(coll2._ddata[keyA]['data'])
+        Amin = np.nanmin(dataA)
     if Amax is None:
-        Amax = np.nanmax(coll2._ddata[keyA]['data'])
+        Amax = np.nanmax(dataA)
     if Bmin is None:
-        Bmin = np.nanmin(coll2._ddata[keyB]['data'])
+        Bmin = np.nanmin(dataB)
     if Bmax is None:
-        Bmax = np.nanmax(coll2._ddata[keyB]['data'])
+        Bmax = np.nanmax(dataB)
 
     # distribution binning
     if nAbin is None:

--- a/datastock/_plot_as_array.py
+++ b/datastock/_plot_as_array.py
@@ -428,7 +428,10 @@ def _plot_as_array_check(
     # vmin, vmax
     if vmin is None:
         if diverging:
-            vmin = -max(abs(nanmin), nanmax)
+            if isinstance(nanmin, np.bool_):
+                vmin = 0
+            else:
+                vmin = -max(abs(nanmin), nanmax)
         else:
             vmin = nanmin
         if vmax is None:


### PR DESCRIPTION
Main changes:
--------------------
* Better handling of bool and sparse arrays for interactivity

Issues:
----------
* Fixes, in devel, issues #26 #27 

Examples:
--------------

```
In [1]: import datastock as ds

In [2]: import scipy.sparse as scpsparse

In [3]: nt0 = 20; t0 = np.linspace(1, 10, nt0); nx = 30; x = np.linspace(1, 10, nx); ny=100; y = np.linspace(0, 10, ny); x0 = 10 + np.sin(t0)[:, None] * (x-x.mean())[None, :]; y0 = x0[:, :, None]*y[None, No
   ...: ne, :] + np.random.normal(scale=0.1, size=(nt0, nx, ny)); tlab0 = [f't = {round(tt)}' for tt in t0]; tlab1 = [f'{round((tt-5)**2)}' for tt in x]; x1 = x0 + np.random.normal(scale=0.1, size=x0.shape)
   ...: ; x2 = x0 + np.random.normal(scale=0.01, size=x0.shape);

In [4]: st = ds.DataStock(); st.add_ref(key='nt', size=nt0); st.add_ref(key='nx', size=nx); st.add_data(key='t0', data=t0); st.add_data(key='x', data=x); st.add_data(key='x0', data=x0); st.add_data(key='y0'
   ...: , data=y0); st.add_data(key='tlab0', data=tlab0); st.add_data(key='tlab1', data=tlab1); st.add_ref(key='ny', size=ny); st.add_data(key='x1', data=x1); st.add_data(key='x2', data=x2);

In [5]: st.add_data(key='bool', data=x1 > np.nanmean(x1)); st.add_data(key='sparse', data=scpsparse.csr_matrix(x1))

In [6]: st
Out[8]: 
ref key  size  nb. data  nb. data monot.
-------  ----  --------  ---------------
nt       20    8         1              
nx       30    8         1              
iref00   100   1         0              
ny       100   0         0              

data key  shape          ref                     monot                 units  dim      quant    name     source 
--------  -------------  ----------------------  --------------------  -----  -------  -------  -------  -------
t0        (20,)          ('nt',)                 (True,)               a.u.   unknown  unknown  unknown  unknown
x         (30,)          ('nx',)                 (True,)               a.u.   unknown  unknown  unknown  unknown
x0        (20, 30)       ('nt', 'nx')            (False, False)        a.u.   unknown  unknown  unknown  unknown
y0        (20, 30, 100)  ('nt', 'nx', 'iref00')  (False, False, True)  a.u.   unknown  unknown  unknown  unknown
tlab0     (20,)          ('nt',)                 (False,)              a.u.   unknown  unknown  unknown  unknown
tlab1     (30,)          ('nx',)                 (False,)              a.u.   unknown  unknown  unknown  unknown
x1        (20, 30)       ('nt', 'nx')            (False, False)        a.u.   unknown  unknown  unknown  unknown
x2        (20, 30)       ('nt', 'nx')            (False, False)        a.u.   unknown  unknown  unknown  unknown
bool      (20, 30)       ('nt', 'nx')            (False, False)        a.u.   unknown  unknown  unknown  unknown
sparse    (20, 30)       ('nt', 'nx')            (False, False)        a.u.   unknown  unknown  unknown  unknown

In [7]: dax = st.plot_as_array('sparse')

In [8]: dax = st.plot_as_array('bool')

```
![image](https://user-images.githubusercontent.com/5929562/162161895-495eab5f-9a21-4a85-a23e-ae2d89f8ce7c.png)

![image](https://user-images.githubusercontent.com/5929562/162161952-21a39428-62df-4955-84b9-13b4c402f27b.png)


