### PR TITLE
Issue042 monotonous vector per dim

### DIFF
--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -605,11 +605,11 @@ class DataStock1(DataStock0):
                 allowed=lkok,
             )
 
-            if ref in refok:
-                hasref = True
+            hasref = ref in refok
+            if hasref:
                 refok = (ref,)
             else:
-                hasref = False
+                refok = tuple()
 
         else:
             hasref = None

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -631,7 +631,7 @@ class DataStock1(DataStock0):
             if self.ddata[k0]['ref'][0] in refok
         ]
 
-        return _class1_interpolate.get_monotonous_vector(
+        return _class1_interpolate.get_ref_vector(
             # ressources
             ddata=self._ddata,
             dref=self._dref,
@@ -644,6 +644,61 @@ class DataStock1(DataStock0):
             values=values,
             indices=indices,
         )
+
+    def get_ref_vector_common(
+        self,
+        keys=None,
+        # for selecting ref vector
+        ref=None,
+        dim=None,
+        quant=None,
+        name=None,
+        units=None,
+        # which ref / dimension
+        **kwdargs,
+    ):
+        """ Return a unique ref vector and a dict of indices
+
+
+        Return
+        ------
+        val:        np.ndarray
+            common finest vector
+        dout:       dict
+            dict of indices, per key, to match val
+
+        """
+
+        # ------------
+        # check inputs
+
+        keys = _generic_check._check_var_iter(
+            keys, 'keys',
+            types=(list, tuple),
+            types_iter=str,
+            allowed=self.ddata.keys(),
+        )
+
+        # ---------------------------
+        # Get ref vector for each key
+
+        din = {
+            k0: self.get_ref_vector(
+                key=k0,
+                ref=ref,
+                dim=dim,
+                quant=quant,
+                name=name,
+                units=units,
+                **kwdargs,
+            )
+            for k0 in keys
+        }
+
+        # ---------------------------
+        # Compute unique vector
+
+        return _class1_interpolate.get_ref_vector_common(din=din)
 
     def interpolate(
         self,
@@ -662,6 +717,9 @@ class DataStock1(DataStock0):
         log_log=None,
         return_params=None,
     ):
+        """ Interpolate keys in desired dimension
+
+        """
         return _class1_interpolate.interpolate(
             # interpolation base
             keys=keys,

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -656,6 +656,10 @@ class DataStock1(DataStock0):
         quant=None,
         name=None,
         units=None,
+        # values, indices
+        values=None,
+        indices=None,
+        ind_strict=None,
         # which ref / dimension
         **kwdargs,
     ):
@@ -701,8 +705,15 @@ class DataStock1(DataStock0):
         # Compute unique vector
 
         return _class1_interpolate.get_ref_vector_common(
+            # ressources
             ddata=self._ddata,
+            dref=self._dref,
+            # inputs
             din=din,
+            # parameters
+            values=values,
+            indices=indices,
+            ind_strict=ind_strict,
         )
 
     def interpolate(

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -552,6 +552,7 @@ class DataStock1(DataStock0):
         # nearest-neighbour interpolation input
         values=None,
         indices=None,
+        ind_strict=None,
         # which ref / dimension
         **kwdargs,
     ):
@@ -643,6 +644,7 @@ class DataStock1(DataStock0):
             # parameters
             values=values,
             indices=indices,
+            ind_strict=ind_strict,
         )
 
     def get_ref_vector_common(

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -559,20 +559,27 @@ class DataStock1(DataStock0):
 
         Typical use: get the time vector of a multidimensional key
 
-        Returns False if the key has no time vector
+        >>> import datastock as ds
+        >>> nt = 11; t0 = np.linspace(0, 10, nt);
+        >>> nx = 21; x = np.linspace(0, 10, nx);
+        >>> xt = np.sin(t0)[:, None] * (x-x.mean())[None, :]
+        >>> st = ds.DataStock()
+        >>> st.add_ref(key='nt', size=nt)
+        >>> st.add_ref(key='nx', size=nx)
+        >>> st.add_data(key='t0', data=t0)
+        >>> st.add_data(key='x', data=x)
+        >>> st.add_data(key='xt', data=xt)
+        >>> hasref, hasvect, ref, key_vect, t, ind, indu, indr = st.get_ref_vector(key='xt', ref='nt', values=[2, 3, 3.1, 5])
 
-        Optional uses:
-            -
-            - get the nearest neighbourg indices between said vector and any
-            user-provided vector
-            -
-
-
-        Parameters
-        ----------
-
-        Return
-        ------
+        In the qbove example:
+            - hasref = True: 'xt' does have 'nt' has ref
+            - hasvect = True: there is a monotonous vector with ref 'nt'
+            - ref = 'nt'
+            - key_vect = 't0'
+            - t = [2, 3, 3.1, 5]: the desired time points
+            - ind = [2, 3, 3, 5]: the indices of t in t0
+            - indu = [2, 3, 5]: the unique indices of t in t0
+            - indr = (3, 4) bool array showing, for each indu, matching ind
 
         """
 

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -539,6 +539,105 @@ class DataStock1(DataStock0):
     # Methods interpolating
     # ---------------------
 
+    def get_ref_vector(
+        self,
+        # key 
+        key=None,
+        # which ref / dimension
+        ref=None,
+        dim=None,
+        quant=None,
+        name=None,
+        units=None,
+        # nearest-neighbour interpolation input
+        values=None,
+        indices=None,
+        # which ref / dimension
+        **kwdargs,
+    ):
+        """ Return the monotonous vector associated to a ref of key
+
+        Typical use: get the time vector of a multidimensional key
+
+        Returns False if the key has no time vector
+
+        Optional uses:
+            -
+            - get the nearest neighbourg indices between said vector and any
+            user-provided vector
+            -
+
+
+        Parameters
+        ----------
+
+        Return
+        ------
+
+        """
+
+        # ------------
+        # check inputs
+
+        # key
+        lkok = list(self.ddata.keys())
+        key = _generic_check._check_var(
+            key, 'key',
+            types=str,
+            allowed=lkok,
+        )
+
+        # ref
+        refok = self.ddata[key]['ref']
+        if ref is not None:
+            lkok = list(self.dref.keys())
+            ref = _generic_check._check_var(
+                ref, 'ref',
+                types=str,
+                allowed=lkok,
+            )
+
+            if ref in refok:
+                hasref = True
+                refok = (ref,)
+            else:
+                hasref = False
+
+        else:
+            hasref = None
+
+        # ------------------------------------------------
+        # get list of monotonous vectors with relevant ref
+
+        lk_vect = [
+            k0 for k0 in self.select(
+                which='data',
+                log='all',
+                returnas=str,
+                monot=(True,),
+                dim=dim,
+                quant=quant,
+                name=name,
+                units=units,
+                **kwdargs,
+            )
+            if self.ddata[k0]['ref'][0] in refok
+        ]
+
+        return _class1_interpolate.get_monotonous_vector(
+            # ressources
+            ddata=self._ddata,
+            dref=self._dref,
+            # inputs
+            key=key,
+            ref=ref,
+            hasref=hasref,
+            lk_vect=lk_vect,
+            # parameters
+            values=values,
+            indices=indices,
+        )
+
     def interpolate(
         self,
         # interpolation base

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -698,7 +698,10 @@ class DataStock1(DataStock0):
         # ---------------------------
         # Compute unique vector
 
-        return _class1_interpolate.get_ref_vector_common(din=din)
+        return _class1_interpolate.get_ref_vector_common(
+            ddata=self._ddata,
+            din=din,
+        )
 
     def interpolate(
         self,

--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -36,8 +36,8 @@ _DDEF_PARAMS = {
 }
 
 
-_IREF = 'iref'
-_IDATA = 'data'
+_IREF = 'n'
+_IDATA = 'd'
 
 
 _DATA_NONE = False

--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -1791,11 +1791,19 @@ def _select(dd=None, dd_name=None, log=None, returnas=None, **kwdargs):
     ind = np.zeros((len(kwdargs), len(dd)), dtype=bool)
     for ii, kk in enumerate(kwdargs.keys()):
         try:
+
+            if kk in lquant:
+                retas = np.ndarray
+            else:
+                retas = dict
+
             par = _get_param(
                 dd=dd, dd_name=dd_name,
                 param=kk,
-                returnas=np.ndarray,
+                returnas=retas,
             )[kk]
+
+            # Numerical quantities
             if kk in lquant:
                 # list => in interval
                 if isinstance(kwdargs[kk], list) and len(kwdargs[kk]) == 2:
@@ -1812,8 +1820,10 @@ def _select(dd=None, dd_name=None, log=None, returnas=None, **kwdargs):
                 # float / int => equal
                 else:
                     ind[ii, :] = par == kwdargs[kk]
+
+            # Non-numerical quantities
             else:
-                ind[ii, :] = par == kwdargs[kk]
+                ind[ii, :] = [pp == kwdargs[kk] for pp in par.values()]
         except Exception as err:
             try:
                 ind[ii, :] = [

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -654,7 +654,8 @@ def get_ref_vector(
         else:
             msg = (
                 "Arg indices must be a bool or int array of indices!\n"
-                f"Provided: {indices}"
+                f"\t- indices.dtype: {indices.dtype}\n"
+                f"\t- indices: {indices}\n"
             )
             raise Exception(msg)
 

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -705,20 +705,14 @@ def get_ref_vector_common(
     # ------------
     # check inputs
 
-    dc = {
-        k0: f"hasref: {v0[0]}, hasvector: {v0[1]}, key_vect: {v0[3]}"
+    din = {
+        k0: v0
         for k0, v0 in din.items()
-        if not (
-            v0[0]   # hasref
-            and v0[1]   # hasvector
-        )
+        if v0[0] and v0[1]
     }
-    if len(dc) > 0:
-        lstr = [f"\t- {k0}: {v0}" for k0, v0 in dc.items()]
-        msg = (
-            "The following keys do not have a ref vector:\n"
-            + "\n".join(lstr)
-        )
+
+    if len(din) == 0:
+        msg = "No keys have a ref vector:\n"
         raise Exception(msg)
 
     # ------------

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -671,12 +671,15 @@ def get_ref_vector(
             raise Exception(msg)
 
         # convert to int
-        if indices.dtype == np.bool_:
+        if 'bool' in indices.dtype.name:
             indices = indices.nonzero()[0]
 
         # derive values
         if values is None:
             values = ddata[key_vector]['data'][indices]
+
+    elif values is None and key_vector is not None:
+        values = ddata[key_vector]['data']
 
     # -------------------
     # indtu, indt_reverse
@@ -685,7 +688,7 @@ def get_ref_vector(
     if indices is not None:
 
         # ind_strict
-        if ind_strict is True and indices is not None:
+        if ind_strict is True and indices is not None and indok is not None:
             values = values[indok]
             indices = indices[indok]
 
@@ -914,5 +917,8 @@ def get_ref_vector_common(
         if indices is not None:
             ind = ind[indices]
         dout = dict.fromkeys(din.keys(), {'ind': ind, 'key_vector': None})
+
+    else:
+        dout = {}
 
     return hasref, hasvect, val, dout

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -570,7 +570,7 @@ def get_ref_vector(
     if len(lk_vect) == 0:
         if hasref is True:
             msg = (
-                f"key {key} was found to have '{ref}' dimension, "
+                f"key '{key}' was found to have '{ref}' dimension, "
                 "but no corresponding vector could be identified!"
             )
             warnings.warn(msg)
@@ -584,8 +584,8 @@ def get_ref_vector(
         if hasref is False:
             msg = (
                 "Contradiction:\n"
-                f"\t- {key} should not have a '{ref}' dimension\n"
-                f"\t- vector {key_vector} identified"
+                f"\t- '{key}' should not have a '{ref}' dimension\n"
+                f"\t- vector '{key_vector}' identified"
             )
             raise Exception(msg)
         else:
@@ -597,12 +597,15 @@ def get_ref_vector(
         if hasref is False:
             msg = (
                 "Contradiction:\n"
-                f"\t- {key} should not have a '{ref}' dimension\n"
+                f"\t- '{key}' should not have a '{ref}' dimension\n"
                 f"\t- Several vectors identified: {lk_vect}"
             )
             raise Exception(msg)
         else:
-            msg = f"Several possible time vectors identified!\n{lk_vect}"
+            msg = (
+                f"Several possible time vectors identified for '{key}'!\n"
+                f"{lk_vect}"
+            )
             raise Exception(msg)
 
     # ref
@@ -713,90 +716,203 @@ def get_ref_vector(
 def get_ref_vector_common(
     # ressources
     ddata=None,
+    dref=None,
     # inputs
     din=None,
+    # parameters
+    values=None,
+    indices=None,
+    ind_strict=None,
 ):
 
     # ------------
     # check inputs
 
-    din = {
-        k0: v0
-        for k0, v0 in din.items()
-        if v0[0] and v0[1]
-    }
-
-    if len(din) == 0:
-        msg = "No keys have a ref vector:\n"
-        raise Exception(msg)
+    # ind_strict
+    ind_strict = _generic_check._check_var(
+        ind_strict, 'ind_strict',
+        types=bool,
+        default=True,
+    )
 
     # ------------
+    # cases
+
+    err = False
+    lref = list(set([v0[2] for v0 in din.values() if v0[0]]))
+
+    # No key has ref dimension
+    if all([not v0[0] for v0 in din.values()]):
+        hasref = False
+        hasvect = False
+
+    # No key has ref vector (but at least one has ref dimension)
+    elif len(lref) == 1:
+        nref = dref[lref[0]]['size']
+        hasref = True
+        hasvect = any([v0[1] for v0 in din.values() if v0[0]])
+
+    # all keys with ref dimension have a ref vector
+    elif len(lref) > 1 and all([v0[1] for v0 in din.values() if v0[0]]):
+        hasref = True
+        hasvect = True
+
+    # some only => error
+    else:
+        err = True
+
+    # raise Error if needed
+    if err:
+        lstr = [f"\t- {k0}: {v0[2]}, {v0[3]}" for k0, v0 in din.items()]
+        msg = (
+            "Chosen keys cannot be used to extract a common ind / value:\n"
+            "They should have either:\n"
+            "\t- no ref\n"
+            "\t- a unique common ref\n"
+            "\t- a set of different ref, each with a vector\n"
+            "Provided:\n"
+            + "\n".join(lstr)
+        )
+        raise Exception(msg)
+
+    # values and indices
+    if values is not None:
+        values = np.atleast_1d(values).ravel()
+
+    if indices is not None:
+        indices = np.atleast_1d(indices).ravel()
+
+    if values is not None and indices is not None:
+        msg = "Please provide values xor indices, not both!"
+        raise Exception(msg)
+
+    if values is not None and not hasvect:
+        msg = (
+            "Arg values cannot be provided because no ref vector exists!"
+        )
+        raise Exception(msg)
+
+    if indices is not None and len(lref) > 1:
+        lstr = [f"\t- {k0}: {v0[2]}, {v0[3]}" for k0, v0 in din.items()]
+        msg = (
+            "Arg indices can only be used if there is a unique common ref!\n"
+            + "\n".join(lstr)
+        )
+        raise Exception(msg)
+
+    # --------
     # compute
 
-    # get list if key_vector and of vectors
-    lkv = list(set([v0[3] for v0 in din.values()]))
-    nv, lv = 0, [ddata[lkv[0]]['data']]
-    for ii in range(1, len(lkv)):
-        c0 = (
-            lv[nv].size == ddata[lkv[ii]]['data'].size
-            and np.allclose(lv[nv], ddata[lkv[ii]]['data'])
-        )
-        if not c0:
-            lv.append(ddata[lkv[ii]]['data'])
-            nv += 1
+    val = None
 
-    if len(lv) == 1:
-        val = lv[0]
-        ind = np.arange(0, len(val))
-        dout = {
-            k0: {
-                'ind': ind,
-                'key_vector': din[k0][3],
-            }
-            for k0 in din.keys()
+    # common vector
+    if hasvect:
+
+        din = {
+            k0: v0[3]
+            for k0, v0 in din.items()
+            if v0[1]
         }
 
-    else:
+        # ------------
+        # compute
 
-        # bounds
-        b0 = np.max([np.min(vv) for vv in lv])
-        b1 = np.min([np.max(vv) for vv in lv])
-
-        if b0 >= b1:
-            msg = (
-                "Non valid common vector values could be identified!"
+        # get list if key_vector and of vectors
+        lkv = list(set([v0 for v0 in din.values()]))
+        nv, lv = 0, [ddata[lkv[0]]['data']]
+        for ii in range(1, len(lkv)):
+            c0 = (
+                lv[nv].size == ddata[lkv[ii]]['data'].size
+                and np.allclose(lv[nv], ddata[lkv[ii]]['data'])
             )
-            warnings.warn(msg)
-            val, dout = None, None
+            if not c0:
+                lv.append(ddata[lkv[ii]]['data'])
+                nv += 1
 
-        else:
-            # increments
-            dv = np.min([np.min(np.diff(vv)) for vv in lv])
-            val = np.linspace(b0, b1, int(np.ceil((b1-b0)/dv)))
-
-            # indices
+        if len(lv) == 1:
+            val = lv[0]
+            ind = np.arange(0, len(val))
             dout = {
-                k0: _get_ref_vector_nearest(ddata[v0[3]]['data'], val)
-                for k0, v0 in din.items()
+                k0: {
+                    'ind': ind,
+                    'key_vector': din[k0],
+                }
+                for k0 in din.keys()
             }
 
-            # only keep all-valid indices
-            iok = np.all(np.array([v0[1] for v0 in dout.values()]), axis=0)
-            if not np.any(iok):
+        else:
+
+            # bounds
+            b0 = np.max([np.min(vv) for vv in lv])
+            b1 = np.min([np.max(vv) for vv in lv])
+
+            if b0 >= b1:
                 msg = (
                     "Non valid common vector values could be identified!"
                 )
                 warnings.warn(msg)
                 val, dout = None, None
+
             else:
-                # adjust
-                val = val[iok]
+                # increments
+                dv = np.min([np.min(np.diff(vv)) for vv in lv])
+                val = np.linspace(b0, b1, int(np.ceil((b1-b0)/dv)))
+
+                # indices
                 dout = {
-                    k0: {
-                        'ind': v0[0][iok],
-                        'key_vector': din[k0][3],
-                    }
-                    for k0, v0 in dout.items()
+                    k0: _get_ref_vector_nearest(ddata[v0]['data'], val)
+                    for k0, v0 in din.items()
                 }
 
-    return val, dout
+                # only keep all-valid indices
+                iok = np.all(np.array([v0[1] for v0 in dout.values()]), axis=0)
+                if not np.any(iok):
+                    msg = (
+                        "Non valid common vector values could be identified!"
+                    )
+                    warnings.warn(msg)
+                    val, dout = None, None
+                else:
+                    # adjust
+                    val = val[iok]
+                    dout = {
+                        k0: {
+                            'ind': v0[0][iok],
+                            'key_vector': din[k0],
+                        }
+                        for k0, v0 in dout.items()
+                    }
+
+        # values
+        if values is not None:
+
+            ind, indok = _get_ref_vector_nearest(val, values)
+
+            if ind_strict:
+                values = values[indok]
+                ind = ind[indok]
+
+            for k0, v0 in dout.items():
+                v0['ind'] = v0['ind'][ind]
+
+            val = values
+
+        elif indices is not None:
+            val = val[indices]
+            for k0, v0 in dout.items():
+                v0['ind'] = v0['ind'][indices]
+
+    # common indices
+    elif hasref:
+        din = {
+            k0: v0
+            for k0, v0 in din.items()
+            if v0[1]
+        }
+        ind = np.arange(0, nref)
+
+        if indices is not None:
+            ind = ind[indices]
+        dout = dict.fromkeys(din.keys(), {'ind': ind, 'key_vector': None})
+
+    return hasref, hasvect, val, dout

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -539,6 +539,7 @@ def get_ref_vector(
     # parameters
     values=None,
     indices=None,
+    ind_strict=None,
 ):
 
     # values
@@ -553,6 +554,13 @@ def get_ref_vector(
     if values is not None and indices is not None:
         msg = "Please provide values xor indices, not both!"
         raise Exception(msg)
+
+    # ind_strict
+    ind_strict = _generic_check._check_var(
+        ind_strict, 'ind_strict',
+        types=bool,
+        default=True,
+    )
 
     # ------------------------
     # hasvector and key_vector
@@ -672,6 +680,13 @@ def get_ref_vector(
 
     ind_reverse = None
     if indices is not None:
+
+        # ind_strict
+        if ind_strict is True and indices is not None:
+            values = values[indok]
+            indices = indices[indok]
+
+        # indu, ind_reverse
         indu = np.unique(indices)
         if indu.size < indices.size:
             ind_reverse = np.array(

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -638,7 +638,7 @@ def get_ref_vector(
     # indices
 
     if indices is not None:
-        if indices.dtype == bool:
+        if 'bool' in indices.dtype.name:
             if indices.size != nref:
                 msg = (
                     f"indt as bool must have shape ({nref},), "
@@ -646,7 +646,7 @@ def get_ref_vector(
                 )
                 raise Exception(msg)
 
-        elif indices.dtype == int:
+        elif 'int' in indices.dtype.name:
             if np.nanmax(indices) >= nref:
                 msg = f"indices as int must be < {nref}\nProvided: {indices}"
                 raise Exception(msg)

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -279,8 +279,8 @@ def _check_pts(pts=None, pts_name=None):
 def _check(
     # interpolation base
     keys=None,
-    ref_keys=None,
-    ref_quant=None,
+    ref_keys=None,      # ddata keys
+    ref_quant=None,     # ddata[ref_key]['quant'], not used yet
     # interpolation pts
     pts_axis0=None,
     pts_axis1=None,
@@ -331,8 +331,9 @@ def _check(
     if ref_keys is None:
         ref_keys = [None for rr in ref]
 
-    if ref_keys == 1 and (ref_keys is None or isinstance(ref_keys, str)):
-        ref_keys = [ref_keys]
+    if isinstance(ref_keys, str):
+        ref_keys = [ref_keys for rr in ref]
+
     c0 = (
         isinstance(ref_keys, list)
         and len(ref_keys) == ndim

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -638,7 +638,7 @@ def get_ref_vector(
     # indices
 
     if indices is not None:
-        if indices.dtype == np.bool_:
+        if indices.dtype == bool:
             if indices.size != nref:
                 msg = (
                     f"indt as bool must have shape ({nref},), "
@@ -646,7 +646,7 @@ def get_ref_vector(
                 )
                 raise Exception(msg)
 
-        elif indices.dtype == np.int_:
+        elif indices.dtype == int:
             if np.nanmax(indices) >= nref:
                 msg = f"indices as int must be < {nref}\nProvided: {indices}"
                 raise Exception(msg)

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -257,6 +257,7 @@ class Test02_Manipulate():
             key='prof0',
             ref='nx',
             values=[1, 2, 2.01, 3],
+            ind_strict=False,
         )
         assert hasref is True and hasvector is True
         assert values.size == indices.size == 4

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -248,7 +248,21 @@ class Test02_Manipulate():
     #   Interpolate
     # ------------------------
 
-    def test06_interpolate(self):
+    def test06_get_ref_vector(self):
+        (
+            hasref, hasvector,
+            ref, key_vector,
+            values, indices, indu, ind_reverse,
+        ) = self.st.get_ref_vector(
+            key='prof0',
+            ref='nx',
+            values=[1, 2, 2.01, 3],
+        )
+        assert hasref is True and hasvector is True
+        assert values.size == indices.size == 4
+        assert ind_reverse.shape == (2, 4)
+
+    def test07_interpolate(self):
         out = self.st.interpolate(
             keys='prof0',
             ref_keys=None,
@@ -269,17 +283,17 @@ class Test02_Manipulate():
     #   Plotting
     # ------------------------
 
-    def test07_plot_as_array(self):
+    def test08_plot_as_array(self):
         dax = self.st.plot_as_array(key='t0')
         dax = self.st.plot_as_array(key='prof0')
         dax = self.st.plot_as_array(key='3d')
         plt.close('all')
 
-    def test08_plot_BvsA_as_distribution(self):
+    def test09_plot_BvsA_as_distribution(self):
         dax = self.st.plot_BvsA_as_distribution(keyA='prof0', keyB='prof0-bis')
         plt.close('all')
 
-    def test09_plot_as_profile1d(self):
+    def test10_plot_as_profile1d(self):
         dax = self.st.plot_as_profile1d(
             key='prof0',
             key_time='t0',
@@ -288,7 +302,7 @@ class Test02_Manipulate():
         )
         plt.close('all')
 
-    def test10_plot_as_mobile_lines(self):
+    def test11_plot_as_mobile_lines(self):
 
         # 3d
         dax = self.st.plot_as_mobile_lines(

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -252,7 +252,7 @@ class Test02_Manipulate():
         (
             hasref, hasvector,
             ref, key_vector,
-            values, indices, indu, ind_reverse,
+            values, indices, indu, ind_reverse, indok,
         ) = self.st.get_ref_vector(
             key='prof0',
             ref='nx',
@@ -262,7 +262,13 @@ class Test02_Manipulate():
         assert values.size == indices.size == 4
         assert ind_reverse.shape == (2, 4)
 
-    def test07_interpolate(self):
+    def test07_get_ref_vector_common(self):
+        val, dout = self.st.get_ref_vector_common(
+            keys=['t0', 'prof0', 'prof1', 't3'],
+            dim='time',
+        )
+
+    def test08_interpolate(self):
         out = self.st.interpolate(
             keys='prof0',
             ref_keys=None,
@@ -283,17 +289,17 @@ class Test02_Manipulate():
     #   Plotting
     # ------------------------
 
-    def test08_plot_as_array(self):
+    def test09_plot_as_array(self):
         dax = self.st.plot_as_array(key='t0')
         dax = self.st.plot_as_array(key='prof0')
         dax = self.st.plot_as_array(key='3d')
         plt.close('all')
 
-    def test09_plot_BvsA_as_distribution(self):
+    def test10_plot_BvsA_as_distribution(self):
         dax = self.st.plot_BvsA_as_distribution(keyA='prof0', keyB='prof0-bis')
         plt.close('all')
 
-    def test10_plot_as_profile1d(self):
+    def test11_plot_as_profile1d(self):
         dax = self.st.plot_as_profile1d(
             key='prof0',
             key_time='t0',
@@ -302,7 +308,7 @@ class Test02_Manipulate():
         )
         plt.close('all')
 
-    def test11_plot_as_mobile_lines(self):
+    def test12_plot_as_mobile_lines(self):
 
         # 3d
         dax = self.st.plot_as_mobile_lines(
@@ -325,7 +331,7 @@ class Test02_Manipulate():
     #   File handling
     # ------------------------
 
-    def test11_copy_equal(self):
+    def test13_copy_equal(self):
         st2 = self.st.copy()
         assert st2 is not self.st
 
@@ -333,10 +339,10 @@ class Test02_Manipulate():
         if msg is not True:
             raise Exception(msg)
 
-    def test12_get_nbytes(self):
+    def test14_get_nbytes(self):
         nb, dnb = self.st.get_nbytes()
 
-    def test13_saveload(self, verb=False):
+    def test15_saveload(self, verb=False):
         pfe = self.st.save(path=_PATH_OUTPUT, verb=verb, return_pfe=True)
         st2 = load(pfe, verb=verb)
         # Just to check the loaded version works fine

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -264,7 +264,7 @@ class Test02_Manipulate():
         assert ind_reverse.shape == (2, 4)
 
     def test07_get_ref_vector_common(self):
-        val, dout = self.st.get_ref_vector_common(
+        hasref, hasvect, val, dout = self.st.get_ref_vector_common(
             keys=['t0', 'prof0', 'prof1', 't3'],
             dim='time',
         )

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -70,7 +70,7 @@ def _add_data(st=None, nc=None, nx=None, lnt=None):
     st.add_data(
         key='x',
         data=x,
-        dimension='distance',
+        dim='distance',
         quant='radius',
         units='m',
         ref='nx',
@@ -80,14 +80,14 @@ def _add_data(st=None, nc=None, nx=None, lnt=None):
         st.add_data(
             key=f't{ii}',
             data=lt[ii],
-            dimension='time',
+            dim='time',
             units='s',
             ref=f'nt{ii}',
         )
         st.add_data(
             key=f'prof{ii}',
             data=lprof[ii],
-            dimension='velocity',
+            dim='velocity',
             units='m/s',
             ref=(f'nt{ii}', 'nx'),
         )
@@ -96,7 +96,7 @@ def _add_data(st=None, nc=None, nx=None, lnt=None):
     st.add_data(
         key='prof2-bis',
         data=lprof[2] + np.random.normal(scale=0.1, size=(lnt[2], nx)),
-        dimension='velocity',
+        dim='velocity',
         units='m/s',
         ref=(f'nt{2}', 'nx'),
     )
@@ -105,7 +105,7 @@ def _add_data(st=None, nc=None, nx=None, lnt=None):
     st.add_data(
         key='prof0-bis',
         data=lprof[0] + np.random.normal(scale=0.1, size=lprof[0].shape),
-        dimensions='blabla',
+        dim='blabla',
         ref=('nt0', 'nx'),
     )
 
@@ -113,7 +113,7 @@ def _add_data(st=None, nc=None, nx=None, lnt=None):
     st.add_data(
         key='3d',
         data=np.arange(nc)[:, None, None] + lprof[0][None, :, :],
-        dimensions='blabla',
+        dim='blabla',
         ref=('nc', 'nt0', 'nx'),
     )
     st.add_data(
@@ -123,7 +123,7 @@ def _add_data(st=None, nc=None, nx=None, lnt=None):
             + lprof[0][None, :, :]
             + np.random.normal(scale=0.01, size=(nc, lnt[0], nx))
         ),
-        dimensions='blabla',
+        dim='blabla',
         ref=('nc', 'nt0', 'nx'),
     )
 
@@ -224,7 +224,7 @@ class Test02_Manipulate():
         key = self.st.select(which='data', units='s', returnas=str)
         assert key.tolist() == ['t0', 't1', 't2', 't3', 't4']
 
-        out = self.st.select(dimension='time', returnas=int)
+        out = self.st.select(dim='time', returnas=int)
         assert len(out) == 5, out
 
         # test quantitative param selection


### PR DESCRIPTION
Main changes:
-------------------
* `get_ref_vector()` implemented
* `get_ref_vector_common()` implemented
* Default names for ref and data are now shorter: `n` and `d` respectively


Issues:
----------
Fixes, in devel, issue #42 

Examples:
--------------
Shorter names:
```

In [1]: import datastock as ds

In [2]: plasma = ds.DataStock();

In [3]: plasma.add_data(key='t', data=np.linspace(0, 10, 11), dim='time')

In [4]: plasma
Out[4]: 
ref key  size  nb. data  nb. data monot.
-------  ----  --------  ---------------
n00      11    1         1              

data key  shape  ref       dim   monot    units  quant  name  source
--------  -----  --------  ----  -------  -----  -----  ----  ------
t         (11,)  ('n00',)  time  (True,)                
```            

ref vectors:

```
In [4]: nt0 = 20; t0 = np.linspace(1, 10, nt0); nx = 30; x = np.linspace(1, 10, nx); ny=100; y = np.linspace(0, 10, ny); x0 = 10 + np.sin(t0)[:, None] * (x-x.mean())[None, :]; y0 = np.cos(x0[:, :, None]*y[N
   ...: one, None, :]) + np.random.normal(scale=0.1, size=(nt0, nx, ny)); tlab0 = [f't = {round(tt)}' for tt in t0]; tlab1 = [f'{round((tt-5)**2)}' for tt in x]; x1 = x0 + np.random.normal(scale=0., size=x0
   ...: .shape); x2 = x0 + np.random.normal(scale=0.01, size=x0.shape); y1 = np.sin(x0[:, :, None]*y[None, None, :]) + np.random.normal(scale=0.1, size=(nt0, nx, ny));

In [8]: st = ds.DataStock(); st.add_ref(key='nt', size=nt0); st.add_ref(key='nx', size=nx); st.add_ref(key='ny', size=ny); st.add_data(key='t0', data=t0, dim='time'); st.add_data(key='x', data=x); st.add_da
   ...: ta(key='x0', data=x0); st.add_data(key='y0', data=y0); st.add_data(key='tlab0', data=tlab0); st.add_data(key='tlab1', data=tlab1); st.add_data(key='x1', data=x1); st.add_data(key='x2', data=x2); st.
   ...: add_data(key='y1', data=y1);

In [9]: st
Out[9]: 
ref key  size  nb. data  nb. data monot.
-------  ----  --------  ---------------
nt       20    7         1              
nx       30    7         1              
ny       100   2         0              

data key  shape          ref                 dim   monot                  units  quant  name  source
--------  -------------  ------------------  ----  ---------------------  -----  -----  ----  ------
t0        (20,)          ('nt',)             time  (True,)                                          
x         (30,)          ('nx',)                   (True,)                                          
x0        (20, 30)       ('nt', 'nx')              (False, False)                                   
y0        (20, 30, 100)  ('nt', 'nx', 'ny')        (False, False, False)                            
tlab0     (20,)          ('nt',)                   (False,)                                         
tlab1     (30,)          ('nx',)                   (False,)                                         
x1        (20, 30)       ('nt', 'nx')              (False, False)                                   
x2        (20, 30)       ('nt', 'nx')              (False, False)                                   
y1        (20, 30, 100)  ('nt', 'nx', 'ny')        (False, False, False)             

In [10]: st.get_ref_vector(key='x0', dim='time')
Out[10]: 
(True,
 True,
 'nt',
 't0',
 array([ 1.        ,  1.47368421,  1.94736842,  2.42105263,  2.89473684,
         3.36842105,  3.84210526,  4.31578947,  4.78947368,  5.26315789,
         5.73684211,  6.21052632,  6.68421053,  7.15789474,  7.63157895,
         8.10526316,  8.57894737,  9.05263158,  9.52631579, 10.        ]),
 None,
 None,
 None,
 None)

In [11]: st.get_ref_vector(key='x0', ref='nx')
Out[11]: 
(True,
 True,
 'nx',
 'x',
 array([ 1.        ,  1.31034483,  1.62068966,  1.93103448,  2.24137931,
         2.55172414,  2.86206897,  3.17241379,  3.48275862,  3.79310345,
         4.10344828,  4.4137931 ,  4.72413793,  5.03448276,  5.34482759,
         5.65517241,  5.96551724,  6.27586207,  6.5862069 ,  6.89655172,
         7.20689655,  7.51724138,  7.82758621,  8.13793103,  8.44827586,
         8.75862069,  9.06896552,  9.37931034,  9.68965517, 10.        ]),
 None,
 None,
 None,
 None)
```
