### PR TITLE
[#50] Implemented _dshow for obj, as class attribute

### DIFF
--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -878,10 +878,12 @@ class DataStock1(DataStock0):
         if anyobj:
             for k0, v0 in self._dobj.items():
                 if 'obj' in show_which or k0 in show_which:
-                    lk = [
-                        kk for kk in self._dshow[k0]
-                        if kk.split('.')[0] in self.get_lparam(which=k0)
-                    ]
+                    lk = _class1_check._show_get_fields(
+                        which=k0,
+                        dobj=self._dobj,
+                        lparam=self.get_lparam(which=k0),
+                        dshow=self._dshow,
+                    )
                     lcol.append([k0] + [pp.split('.')[-1] for pp in lk])
                     lar.append([
                         [k1] + _class1_check._show_extract(dobj=v1, lk=lk)

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -133,7 +133,7 @@ class DataStock1(DataStock0):
 
         # show dict
         if which not in self._dshow.keys():
-            lk = self.get_lparam(which=k0)
+            lk = self.get_lparam(which=which)
             lk = [
                 kk for kk in lk
                 if 'func' not in kk

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -60,6 +60,7 @@ class DataStock1(DataStock0):
     _show_in_summary_core = ['shape', 'ref']
     _show_in_summary = 'all'
     _max_ndim = None
+    _dshow = {}
 
     def __init__(
         self,
@@ -129,6 +130,22 @@ class DataStock1(DataStock0):
         dobj = {which: {key: kwds}}
         # Check consistency
         self.update(dobj=dobj, dref=None, harmonize=harmonize)
+
+        # show dict
+        if which not in self._dshow.keys():
+            lk = self.get_lparam(which=k0)
+            lk = [
+                kk for kk in lk
+                if 'func' not in kk
+                and 'class' not in kk
+                and kk not in ['handle']
+                and not (which == 'axes' and kk == 'bck')
+                and all([
+                    not isinstance(v1[kk], dict)
+                    for v1 in self._dobj[which].values()
+                ])
+            ]
+            self._dshow[which] = lk
 
     # ---------------------
     # Removing ref / quantities
@@ -861,21 +878,13 @@ class DataStock1(DataStock0):
         if anyobj:
             for k0, v0 in self._dobj.items():
                 if 'obj' in show_which or k0 in show_which:
-                    lk = self.get_lparam(which=k0)
                     lk = [
-                        kk for kk in lk
-                        if 'func' not in kk
-                        and 'class' not in kk
-                        and kk not in ['handle']
-                        and not (k0 == 'axes' and kk == 'bck')
-                        and all([
-                            not isinstance(v1[kk], dict)
-                            for v1 in v0.values()
-                        ])
+                        kk for kk in self._dshow[k0]
+                        if kk.split('.')[0] in self.get_lparam(which=k0)
                     ]
-                    lcol.append([k0] + [pp for pp in lk])
+                    lcol.append([k0] + [pp.split('.')[-1] for pp in lk])
                     lar.append([
-                        [k1] + [str(v1[kk]) for kk in lk]
+                        [k1] + _class1_check._show_extract(dobj=v1, lk=lk)
                         for k1, v1 in v0.items()
                     ])
 

--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -1868,3 +1868,25 @@ def _select(dd=None, dd_name=None, log=None, returnas=None, **kwdargs):
                 dtype=str,
             )
     return ind
+
+
+#############################################
+#############################################
+#       show
+#############################################
+
+
+def _show_extract(dobj=None, lk=None):
+
+    lv0 = []
+    for k0 in lk:
+
+        lk0 = k0.split('.')
+        for ii in range(len(lk0)):
+            if ii == 0:
+                v0 = dobj[lk0[ii]]
+            else:
+                v0 = v0[lk0[ii]]
+
+        lv0.append(str(v0))
+    return lv0

--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -1887,7 +1887,7 @@ def _show_get_fields(which=None, dobj=None, lparam=None, dshow=None):
             and not (which == 'axes' and kk == 'bck')
             and all([
                 not isinstance(v1[kk], dict)
-                for v1 in self._dobj[which].values()
+                for v1 in dobj[which].values()
             ])
         ]
     else:

--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -1876,6 +1876,25 @@ def _select(dd=None, dd_name=None, log=None, returnas=None, **kwdargs):
 #############################################
 
 
+def _show_get_fields(which=None, dobj=None, lparam=None, dshow=None):
+    # show dict
+    if which not in dshow.keys():
+        lk = [
+            kk for kk in lparam
+            if 'func' not in kk
+            and 'class' not in kk
+            and kk not in ['handle']
+            and not (which == 'axes' and kk == 'bck')
+            and all([
+                not isinstance(v1[kk], dict)
+                for v1 in self._dobj[which].values()
+            ])
+        ]
+    else:
+        lk = dshow[which]
+        lk = [kk for kk in dshow[which] if kk.split('.')[0] in lparam]
+    return lk
+
 def _show_extract(dobj=None, lk=None):
 
     lv0 = []


### PR DESCRIPTION
Attribute `_dshow` allows to define custom fields to be displayed by method `show()` for objects.
Simply provide a dict of key / list pairs, giving the list of attributes to be displayed for each obj category.

Syntax allows to access sub-dict by providing the path using a dot `.` as sub-dict separator.


Example:
------------

```
In [1]: st = ds.DataStock()

In [2]: st.add_obj(which='blabla', key='bla0', att0=1, att1='A', att2={'a': 3, 'b': 4})

In [3]: st
Out[3]: 
blabla  att0  att1
------  ----  ----
bla0    1     A   

In [4]: st._dshow['blabla'] = ['att1', 'att2.b']

In [5]: st
Out[5]: 
blabla  att1  b
------  ----  -
bla0    A     4
```