### PR TITLE
[#54] Better _generci_check routines + show_obj()

### DIFF
--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -53,6 +53,12 @@ class DataStock1(DataStock0):
          },
     }
 
+    # short names
+    _dshort = {
+        'ref': 'n',
+        'data': 'd',
+    }
+
     # _dallowed_params = None
     _data_none = None
     _reserved_keys = None
@@ -110,6 +116,7 @@ class DataStock1(DataStock0):
             data_none=self._data_none,
             max_ndim=self._max_ndim,
             harmonize=harmonize,
+            dshort=self._dshort,
         )
 
     # ---------------------
@@ -794,6 +801,16 @@ class DataStock1(DataStock0):
 
         if show_which is None:
             show_which = ['ref', 'data', 'obj']
+        elif isinstance(show_which, tuple):
+            if 'obj' in show_which:
+                show_which = [
+                    k0 for k0 in ['ref', 'data'] if k0 not in show_which
+                ]
+            else:
+                show_which = [
+                    k0 for k0 in ['ref', 'data'] + list(self._dobj.keys())
+                    if k0 not in show_which
+                ]
 
         lcol, lar = [], []
 
@@ -900,11 +917,11 @@ class DataStock1(DataStock0):
             returnas=returnas,
         )
 
-    def show_all(self):
-        self.show(show_which=None)
-
     def show_data(self):
         self.show(show_which=['ref', 'data'])
+
+    def show_obj(self):
+        self.show(show_which=('ref', 'data'))
 
     def show_interactive(self):
         self.show(show_which=['axes', 'mobile', 'interactivity'])

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -140,7 +140,7 @@ class DataStock1(DataStock0):
 
         # show dict
         if which not in self._dshow.keys():
-            lk = self.get_lparam(which=which)
+            lk = self.get_lparam(which=which, for_show=True)
             lk = [
                 kk for kk in lk
                 if 'func' not in kk
@@ -221,7 +221,7 @@ class DataStock1(DataStock0):
             return_dict=return_dict,
         )
 
-    def get_lparam(self, which=None):
+    def get_lparam(self, which=None, for_show=None):
         """ Return the list of params for the chosen dict
 
         which can be:
@@ -230,7 +230,9 @@ class DataStock1(DataStock0):
             - dobj[<which>]
         """
         which, dd = self.__check_which(which, return_dict=True)
-        return list(list(dd.values())[0].keys())
+        if which in ['ref', 'data']:
+            for_show = False
+        return _class1_check._get_lparam(dd=dd, for_show=for_show)
 
     def get_param(
         self,
@@ -898,7 +900,7 @@ class DataStock1(DataStock0):
                     lk = _class1_check._show_get_fields(
                         which=k0,
                         dobj=self._dobj,
-                        lparam=self.get_lparam(which=k0),
+                        lparam=self.get_lparam(which=k0, for_show=True),
                         dshow=self._dshow,
                     )
                     lcol.append([k0] + [pp.split('.')[-1] for pp in lk])

--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -36,10 +36,6 @@ _DDEF_PARAMS = {
 }
 
 
-_IREF = 'n'
-_IDATA = 'd'
-
-
 _DATA_NONE = False
 
 
@@ -299,6 +295,7 @@ def _remove_ref(
     ddefparams_obj=None,
     data_none=None,
     max_ndim=None,
+    dshort=None,
 ):
     """ Remove a ref (or list of refs) and all associated data """
 
@@ -328,6 +325,7 @@ def _remove_ref(
         data_none=data_none,
         max_ndim=max_ndim,
         harmonize=True,
+        dshort=dshort,
     )
 
 
@@ -345,6 +343,7 @@ def _remove_data(
     ddefparams_obj=None,
     data_none=None,
     max_ndim=None,
+    dshort=None,
 ):
     """ Remove a ref (or list of refs) and all associated data """
 
@@ -391,6 +390,7 @@ def _remove_data(
         data_none=data_none,
         max_ndim=max_ndim,
         harmonize=True,
+        dshort=dshort,
     )
 
 
@@ -408,6 +408,7 @@ def _remove_obj(
     ddefparams_obj=None,
     data_none=None,
     max_ndim=None,
+    dshort=None,
 ):
 
     # ------------
@@ -450,6 +451,7 @@ def _remove_obj(
         data_none=data_none,
         max_ndim=max_ndim,
         harmonize=True,
+        dshort=dshort,
     )
 
 
@@ -509,6 +511,7 @@ def _check_dref(
     dref=None,
     dref0=None,
     ddata0=None,
+    dshort=None,
 ):
     """ Check and format dref
 
@@ -538,16 +541,8 @@ def _check_dref(
     for k0, v0 in dref.items():
 
         # key
-        nmax = _generic_check._name_key(
-            dd=dref0, dd_name='dref0', keyroot=_IREF,
-        )[1]
-        key = f'{_IREF}{nmax:02.0f}'
-
-        key = _generic_check._check_var(
-            k0,
-            'k0',
-            types=str,
-            default=key,
+        key = _generic_check._obj_key(
+            d0=dref0, short=dshort.get('ref', 'n'), key=k0,
         )
 
         # v0
@@ -713,6 +708,7 @@ def _get_suitable_ref(
     dref0=None,
     dref_add=None,
     axis=None,
+    dshort=None,
 ):
     """  For each dimension of data.shape, identify the relevant ref index """
 
@@ -741,18 +737,18 @@ def _get_suitable_ref(
 
     # no match => create new ref
     else:
-        nmax0 = _generic_check._name_key(
-            dd=dref0, dd_name='dref', keyroot=_IREF,
-        )[1]
-        nmax1 = _generic_check._name_key(
-            dd=dref_add, dd_name='dref_add', keyroot=_IREF,
-        )[1]
-        lref = f'{_IREF}{max(nmax0, nmax1):02.0f}'
+        key = _generic_check._obj_key(d0=dref0, short=dshort['ref'])
 
     return lref, size
 
 
-def _check_data_ref(k0=None, ddata=None, dref0=None, dref_add=None):
+def _check_data_ref(
+    k0=None,
+    ddata=None,
+    dref0=None,
+    dref_add=None,
+    dshort=None,
+):
 
     if dref_add is None:
         dref_add = {}
@@ -767,6 +763,7 @@ def _check_data_ref(k0=None, ddata=None, dref0=None, dref_add=None):
                 dref0=dref0,
                 dref_add=dref_add,
                 axis=ii,
+                dshort=dshort,
             )
 
             if ref not in dref0.keys() and ref not in dref_add.keys():
@@ -808,6 +805,7 @@ def _check_ddata(
     reserved_keys=None,
     data_none=None,
     max_ndim=None,
+    dshort=None,
 ):
 
     # ----------------
@@ -903,16 +901,8 @@ def _check_ddata(
     for k0, v0 in ddata.items():
 
         # key
-        nmax = _generic_check._name_key(
-            dd=ddata0, dd_name='ddata0', keyroot=_IDATA,
-        )[1]
-        key = f'{_IDATA}{nmax:02.0f}'
-
-        key = _generic_check._check_var(
-            k0,
-            'k0',
-            types=str,
-            default=key,
+        key = _generic_check._obj_key(
+            d0=ddata0, short=dshort['data'], key=k0,
         )
 
         # convert to dict if needed
@@ -932,7 +922,11 @@ def _check_ddata(
             ddata[k0]['ref'] = (v0['ref'],)
 
         _check_data_ref(
-            k0=k0, ddata=ddata, dref0=dref0, dref_add=dref_add,
+            k0=k0,
+            ddata=ddata,
+            dref0=dref0,
+            dref_add=dref_add,
+            dshort=dshort,
         )
 
         ddata2[key] = dict(ddata[k0])
@@ -976,6 +970,7 @@ def _check_ddata(
 def _check_dobj(
     dobj=None,
     dobj0=None,
+    dshort=None,
 ):
 
     # ----------------
@@ -1026,16 +1021,11 @@ def _check_dobj(
         # set None to default keys if any None
         dobj2[k0] = {}
         for k1 in v0.keys():
-            nmax = _generic_check._name_key(
-                dd=dobj0.get(k0, {}), dd_name=f"dobj0['{k0}']", keyroot=k0[:3],
-            )[1]
-            key = f'{k0[:3]}{nmax:02.0f}'
 
-            key = _generic_check._check_var(
-                k1,
-                'k1',
-                types=str,
-                default=key,
+            key = _generic_check._obj_key(
+                d0=dobj0.get(k0, {}),
+                short=dshort.get(k0, k0[:4]),
+                key=k1,
             )
 
             dobj2[k0][key] = dict(dobj[k0][k1])
@@ -1240,6 +1230,7 @@ def _consistency(
     data_none=None,
     max_ndim=None,
     harmonize=None,
+    dshort=None,
 ):
 
     # --------------
@@ -1255,7 +1246,7 @@ def _consistency(
     # dref
 
     dref, ddata_add = _check_dref(
-        dref=dref, dref0=dref0, ddata0=ddata0,
+        dref=dref, dref0=dref0, ddata0=ddata0, dshort=dshort,
     )
     if ddata_add is not None:
         if ddata is None:
@@ -1273,6 +1264,7 @@ def _consistency(
         reserved_keys=reserved_keys,
         data_none=data_none,
         max_ndim=max_ndim,
+        dshort=dshort,
     )
     if dref_add is not None:
         dref0.update(dref_add)
@@ -1282,7 +1274,7 @@ def _consistency(
     # dobj
 
     dobj = _check_dobj(
-        dobj=dobj, dobj0=dobj0,
+        dobj=dobj, dobj0=dobj0, dshort=dshort,
     )
     for k0, v0 in dobj.items():
         if k0 not in dobj0.keys():
@@ -1366,65 +1358,6 @@ def _consistency(
             if pp not in self._reserved_all and pp not in lparam:
                 lparam.append(pp)
 """
-
-
-# #############################################################################
-# #############################################################################
-#               Switch ref
-# #############################################################################
-
-
-# DEPRECATED ?
-# def switch_ref(
-    # new_ref=None,
-    # ddata=None,
-    # dref=None,
-    # dobj0=None,
-    # reserved_keys=None,
-    # ddefparams_data=None,
-    # data_none=None,
-    # max_ndim=None,
-# ):
-    # """Use the provided key as ref (if valid) """
-
-    # # Check input
-    # c0 = (
-        # new_ref in ddata.keys()
-        # and ddata[new_ref].get('monot') == (True,)
-    # )
-    # if not c0:
-        # msg = (
-            # "\nArg new_ref must be a key to a valid ref (monotonous)!\n"
-            # + "\t- Provided: {}\n\n".format(new_ref)
-            # + "Available valid ref candidates:\n"
-            # + "\t- {}".format('\n\t- '.join(list(dref.keys())))
-        # )
-        # raise Exception(msg)
-
-    # # Substitute in dref
-    # old_ref = ddata[new_ref]['ref'][0]
-    # dref[new_ref] = dict(dref[old_ref])
-    # del dref[old_ref]
-
-    # # substitute in ddata['ref']
-    # for k0, v0 in ddata.items():
-        # if v0.get('ref') is not None and old_ref in v0['ref']:
-            # new = tuple([rr for rr in v0['ref']])
-            # ddata[k0]['ref'] = tuple([
-                # new_ref if rr == old_ref else rr
-                # for rr in v0['ref']
-            # ])
-
-    # return _consistency(
-        # ddata=ddata, ddata0={},
-        # dref=dref, dref0={},
-        # dobj=None, dobj0=dobj0,
-        # reserved_keys=None,
-        # ddefparams_data=ddefparams_data,
-        # ddefparams_obj=None,
-        # data_none=None,
-        # max_ndim=None,
-    # )
 
 
 # #############################################################################

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -86,9 +86,9 @@ def _check_var(
     if sign is not None:
         err = False
         if np.isscalar(var):
-            if not eval(f'{var} {sign}'):
+            if not eval(f'var {sign}'):
                 err = True
-        elif not np.all(eval(f'np.asarray({var}) {sign}')):
+        elif not np.all(eval(f'np.asarray(var) {sign}')):
             err = True
 
         if err is True:
@@ -214,7 +214,7 @@ def _check_flat1darray(
 
     # sign
     if sign is not None:
-        if np.all(eval(f'np.asarray({var}) {sign}')):
+        if not np.all(eval(f'var {sign}')):
             msg = (
                 f"Arg {varname} must be {sign}\n"
                 f"Provided: {var}"
@@ -287,6 +287,9 @@ def _check_dict_valid_keys(
                 if var.get(k0) is None:
                     var[k0] = None
                     continue
+
+            if 'can_be_None' in v0:
+                del v0['can_be_None']
 
             vv = var.get(k0)
 

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -455,8 +455,8 @@ def _obj_key(d0=None, short=None, key=None):
             nb = 0
         else:
             lnb = [
-                int(k0[2:]) for k0 in lout if k0.startswith(short)
-                and k0[2:].isnumeric()
+                int(k0[len(short):]) for k0 in lout if k0.startswith(short)
+                and k0[len(short):].isnumeric()
             ]
             nb = min([ii for ii in range(max(lnb)+2) if ii not in lnb])
         key = f'{short}{nb}'

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -324,7 +324,7 @@ def _get_horizontal_unitvect(ee=None):
         eout = np.r_[ee[1], -ee[0], 0]
     else:
         eout = np.r_[1, 0, 0.]
-    return _check_flat1darray(eout, 'eout', size=dim, dtype=float, norm=True)
+    return _check_flat1darray(eout, 'eout', size=3, dtype=float, norm=True)
 
 
 def _get_vertical_unitvect(ee=None):
@@ -333,7 +333,7 @@ def _get_vertical_unitvect(ee=None):
         eout = np.r_[-ee[2]*ee[0], -ee[2]*ee[1], eh]
     else:
         eout = _get_horizontal_unitvect(ee=ee)
-    return _check_flat1darray(eout, 'eout', size=dim, dtype=float, norm=True)
+    return _check_flat1darray(eout, 'eout', size=3, dtype=float, norm=True)
 
 
 def _check_vectbasis(

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -182,6 +182,7 @@ def _check_flat1darray(
     size=None,
     sign=None,
     norm=None,
+    can_be_None=None,
 ):
 
     # Default inputs
@@ -192,7 +193,18 @@ def _check_flat1darray(
     if var is None:
         return None
 
+    # can_be_None
+    if can_be_None is None:
+        can_be_None = False
+
     # Format to flat 1d array and check size
+    if var is None:
+        if can_be_None is False:
+            msg = f"Arg {varname} is None!"
+            raise Exception(msg)
+        else:
+            return
+
     var = np.atleast_1d(var).ravel()
 
     # size

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -392,9 +392,9 @@ def _check_vectbasis(
         if e0 is None and e1 is None:
             e1 = _get_horizontal_unitvect(ee=e2)
         elif e0 is None and e2 is None:
-            e2 = _get_vertical_unitvect(ee=e2)
+            e2 = _get_vertical_unitvect(ee=e1)
         elif e1 is None and e2 is None:
-            e2 = _get_vertical_unitvect(ee=e2)
+            e2 = _get_vertical_unitvect(ee=e0)
 
         # complete if 1 missing
         if e0 is None:

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -189,21 +189,17 @@ def _check_flat1darray(
     if norm is None:
         norm = False
 
-    # Return None of None
-    if var is None:
-        return None
-
     # can_be_None
     if can_be_None is None:
         can_be_None = False
 
     # Format to flat 1d array and check size
     if var is None:
-        if can_be_None is False:
+        if can_be_None is True:
+            return
+        else:
             msg = f"Arg {varname} is None!"
             raise Exception(msg)
-        else:
-            return
 
     var = np.atleast_1d(var).ravel()
 

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -196,14 +196,17 @@ def _check_flat1darray(
     var = np.atleast_1d(var).ravel()
 
     # size
-    if size is None and var.size != size:
-        msg = (
-            f"Arg {varname} should be convertible to a 1d np.ndarray with:\n"
-            f"\t- size = {size}\n"
-            f"\t- dtype = {dtype}\n"
-            f"Provided:\n{var}"
-        )
-        raise Exception(msg)
+    if size is None:
+        if np.isscalar(size):
+            size = [size]
+        if var.size not in size:
+            msg = (
+                f"Arg {varname} should be a 1d np.ndarray with:\n"
+                f"\t- size = {size}\n"
+                f"\t- dtype = {dtype}\n"
+                f"Provided:\n{var}"
+            )
+            raise Exception(msg)
 
     # dtype
     if dtype is not None:

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -180,6 +180,7 @@ def _check_flat1darray(
     varname=None,
     dtype=None,
     size=None,
+    sign=None,
     norm=None,
 ):
 
@@ -208,6 +209,15 @@ def _check_flat1darray(
     if dtype is not None:
         var = var.astype(dtype)
 
+    # sign
+    if sign is not None:
+        if np.all(eval(f'np.asarray({var}) {sign}')):
+            msg = (
+                f"Arg {varname} must be {sign}\n"
+                f"Provided: {var}"
+            )
+            raise Exception(msg)
+
     # Normalize
     if norm is True:
         var = var / np.linalg.norm(var)
@@ -227,6 +237,7 @@ def _check_dict_valid_keys(
     dkeys=None,
     has_all_keys=None,
     has_only_keys=None,
+    keys_can_be_None=None,
 ):
     """ Check dict has expected keys """
 
@@ -261,7 +272,22 @@ def _check_dict_valid_keys(
 
     # keys types constraints
     if isinstance(dkeys, dict):
+
+        if keys_can_be_None is not None:
+            for k0, v0 in dkeys.items():
+                dkeys[k0]['can_be_None'] = keys_can_be_None
+
         for k0, v0 in dkeys.items():
+
+            # policy vs None
+            if v0.get('can_be_None', False) is True:
+                if var.get(k0) is None:
+                    var[k0] = None
+                    continue
+
+            vv = var.get(k0)
+
+            # routine to call
             if any(['iter' in ss for ss in v0.keys()]):
                 var[k0] = _check_var_iter(
                     var[k0],

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -243,6 +243,9 @@ class Test02_Manipulate():
 
     def test05_show(self):
         self.st.show()
+        self.st.show_data()
+        self.st.show_obj()
+        self.st.show_interactive()
 
     # ------------------------
     #   Interpolate


### PR DESCRIPTION
Main changes:
--------------------
* `_generic_check._check_var(sign=...)` implemented to check the sign with a regular expression (any inequality)
* `_generic_check._check_flat1darray(size=..., dtype=..., norm=bool, can_be_None=bool)` implemented 
* `_generic_check._check_dict_valid_keys()` will check the keys of a dict (all, any + dict of key types fed to `_check_var`, `_check_var_iter` or `_check_flat1darray`)
* `_generic_check._obj_key()` implemented to set `None` key to default short (using new `_dshort `class attribute)
* `show(show_which=tuple)` implemented, allowing `show_obj()`
* `_generic_check._check_vectbasis(e0=..., e1=..., e2=..., dim=...)` implemented for 2d and 3d vector basis
* `get_lparam()` now properly handles nested dict

Issues:
----------
* Fixes, in devel, issues #52, #53, #54