### PR TITLE
Issue57 astropy units

### DIFF
--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -39,17 +39,9 @@ class DataStock1(DataStock0):
     # Fixed (class-wise) dictionary of default properties
     _ddef = {
         'params': {
-            'dref': {
-            },
-            'ddata': {
-                'units':  (str, ''),
-                'dim':    (str, ''),
-                'quant':  (str, ''),
-                'name':   (str, ''),
-                'source': (str, ''),
-            },
-            'dobj': {
-            },
+            'dref': None,
+            'ddata': None,
+            'dobj': None,
          },
     }
 

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -7,6 +7,7 @@ import copy
 
 # Common
 import numpy as np
+import astropy.units as asunits
 
 
 # library-specific
@@ -39,9 +40,15 @@ class DataStock1(DataStock0):
     # Fixed (class-wise) dictionary of default properties
     _ddef = {
         'params': {
-            'dref': None,
-            'ddata': None,
-            'dobj': None,
+            'dref': {},
+            'ddata': {
+                'source': (str, ''),
+                'dim':    (str, ''),
+                'quant':  (str, ''),
+                'name':   (str, ''),
+                'units':  ((str, asunits.core.UnitBase), ''),
+            },
+            'dobj': {},
          },
     }
 

--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -1902,10 +1902,15 @@ def _show_extract(dobj=None, lk=None):
 
         # formatting
         if isinstance(v0, float):
-            lv0.append(f'{v0:.3e}')
+            lv0.append(f'{v0:.2e}')
         elif isinstance(v0, np.ndarray) and v0.size == 3:
             if v0.dtype == np.float:
-                lv0.append(str([f'{vv:.3e}' for vv in v0]))
+                lv0.append(
+                    np.array2string(
+                        v0,
+                        formatter={'float': lambda x: f'{x:.3e}'},
+                    ),
+                )
             else:
                 lv0.append(str(v0))
         else:

--- a/datastock/_generic_utils.py
+++ b/datastock/_generic_utils.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import scipy.sparse as scpsp
+import astropy.units as asunits
 
 
 from . import _generic_check
@@ -365,7 +366,7 @@ def compare_dict(d0=None, d1=None, dname=None, returnas=None, verb=None):
 
         # functions
         elif callable(d0[k0]):
-            if d0[k0] == d1[k0]:
+            if d0[k0] != d1[k0]:
                 dkeys[key] = "!= callable"
 
         # dict
@@ -379,6 +380,11 @@ def compare_dict(d0=None, d1=None, dname=None, returnas=None, verb=None):
             )
             if isinstance(dd, dict):
                 dkeys.update(dd)
+
+        # units (astropy)
+        elif isinstance(d0[k0], asunits.core.UnitBase):
+            if d0[k0] != d1[k0]:
+                dkeys[key] = f'!= astropy units ({d0[k0]} vs {d1[k0]})'
 
         # not implemented cases
         else:

--- a/datastock/_saveload.py
+++ b/datastock/_saveload.py
@@ -6,6 +6,7 @@ import datetime as dtm
 
 
 import numpy as np
+import astropy.units as asunits
 
 
 from . import _generic_check
@@ -70,7 +71,7 @@ def save(
         types=bool,
     )
 
-    # ----------------------
+    # -----------------------
     # store initial data type
 
     dtypes = {
@@ -78,6 +79,11 @@ def save(
         for k0, v0 in dflat.items()
     }
     dflat.update(dtypes)
+
+    # convert astropy units to str
+    for k0, v0 in dflat.items():
+        if isinstance(v0, asunits.core.UnitBase):
+            dflat[k0] = str(v0)
 
     # ----------------------
     # save / print / return
@@ -169,6 +175,8 @@ def load(
             dout[k0] = None
         elif typ == 'ndarray':
             dout[k0] = dflat[k0]
+        elif 'Unit' in typ:
+            dout[k0] = eval(f"asunits.{v0}")
         else:
             msg = (
                 f"Don't know how to deal with dflat['{k0}']: {typ}"

--- a/datastock/_saveload.py
+++ b/datastock/_saveload.py
@@ -165,9 +165,9 @@ def load(
             dout[k0] = list(dflat[k0])
         elif typ == 'str':
             dout[k0] = str(dflat[k0])
-        elif typ == 'int':
+        elif typ in ['int', 'int32', 'int64']:
             dout[k0] = int(dflat[k0])
-        elif typ == 'float':
+        elif typ in ['float', 'float32', 'float64']:
             dout[k0] = float(dflat[k0])
         elif typ == 'bool':
             dout[k0] = bool(dflat[k0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 numpy
 scipy
 matplotlib
+astropy

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
         "numpy",
         "scipy",
         "matplotlib",
+        "astropy",
     ],
     python_requires=">=3.6",
 


### PR DESCRIPTION
Main changes:
--------------------
* `astropy` is now a dependency
* `units` are now by default astropy units
* `show()` now uses `'{:.3e}'` for floats and arrays of 3 floats

Issues:
---------
* Fixes, in devel, issues #57 , #60