### PR TITLE
Issue063 dax error msg + 62 better astropy units conversions

### DIFF
--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -1130,8 +1130,10 @@ def _harmonize_params(
         for k1, v1 in dd.items():
             if v1.get('units') is not None and v1['units'] != '':
                 if isinstance(v1['units'], str):
-                    if hasattr(asunits, v1['units']):
-                        dd[k1]['units'] = eval(f"asunits.{v1['units']}")
+                    try:
+                        dd[k1]['units'] = asunits.Unit(v1['units'])
+                    except Exception as err:
+                        pass
 
     # -------------------
     # Check against dobj0

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -562,7 +562,7 @@ def _check_dax(dax=None, main=None):
                 or (
                     isinstance(v0, dict)
                     and issubclass(v0.get('handle').__class__, plt.Axes)
-                    and v0.get('type') in _LALLOWED_AXESTYPES
+                    # and v0.get('type') in _LALLOWED_AXESTYPES
                 )
             )
             for k0, v0 in dax.items()
@@ -570,9 +570,14 @@ def _check_dax(dax=None, main=None):
     )
     if not c0:
         msg = (
+            "Wrong dax:\n"
+            "Should be a dict of plt.Axes or of dict of plt.Axes in 'handle'\n"
         )
-        import pdb; pdb.set_trace()     # DB
-        pass
+        if isinstance(dax, dict):
+            lstr = [f"\t- '{k0}': {v0}" for k0, v0 in dax.items()]
+            msg += "\n" + "\n".join(lstr)
+        else:
+            msg += f"{dax}"
         raise Exception(msg)
 
     for k0, v0 in dax.items():

--- a/datastock/_saveload.py
+++ b/datastock/_saveload.py
@@ -176,7 +176,7 @@ def load(
         elif typ == 'ndarray':
             dout[k0] = dflat[k0]
         elif 'Unit' in typ:
-            dout[k0] = eval(f"asunits.{v0}")
+            dout[k0] = asunits.Unit(v0.tolist())
         else:
             msg = (
                 f"Don't know how to deal with dflat['{k0}']: {typ}"


### PR DESCRIPTION
Main changes:
-------------------
* `_generic_check._check_dax() `pproduces better error message for `dax`, and is more robust (no `type` check)
* `Astropy` units conversion is more robust and uses the `Unit(str)` syntax

Issues:
---------
* Fixes, in devel:
    - issue #62 
    - issue #63  