### PR TITLE
Numpy deprecation on ragged arrays

### DIFF
--- a/datastock/_class0.py
+++ b/datastock/_class0.py
@@ -17,7 +17,7 @@ class DataStock0(object):
     def __init__(self):
         self.__object = object()
 
-    def to_dict(self, flatten=None, sep=None):
+    def to_dict(self, flatten=None, sep=None, asarray=None, with_types=None):
         """ Return a flat dict view of the object's attributes
 
         Useful for:
@@ -67,7 +67,13 @@ class DataStock0(object):
         # optional flattening
 
         if flatten is True:
-            dout = _generic_utils.flatten_dict(dout, parent_key=None, sep=sep)
+            dout = _generic_utils.flatten_dict(
+                dout,
+                parent_key=None,
+                sep=sep,
+                asarray=asarray,
+                with_types=with_types,
+            )
 
         return dout
 
@@ -168,7 +174,12 @@ class DataStock0(object):
 
         # call parent method
         return _saveload.save(
-            dflat=self.to_dict(flatten=True, sep=sep),
+            dflat=self.to_dict(
+                flatten=True,
+                sep=sep,
+                asarray=True,
+                with_types=True,
+            ),
             path=path,
             name=name,
             clsname=self.__class__.__name__,

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -42,11 +42,11 @@ class DataStock1(DataStock0):
         'params': {
             'dref': {},
             'ddata': {
-                'source': (str, ''),
-                'dim':    (str, ''),
-                'quant':  (str, ''),
-                'name':   (str, ''),
-                'units':  ((str, asunits.core.UnitBase), ''),
+                'source': {'cls': str, 'def': ''},
+                'dim':    {'cls': str, 'def': ''},
+                'quant':  {'cls': str, 'def': ''},
+                'name':   {'cls': str, 'def': ''},
+                'units':  {'cls': (str, asunits.core.UnitBase), 'def': ''},
             },
             'dobj': {},
          },

--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -26,11 +26,11 @@ _LRESERVED_KEYS = list(set(itt.chain.from_iterable([
 
 _DDEF_PARAMS = {
     'ddata': {
-        'source': (str, ''),
-        'dim':    (str, ''),
-        'quant':  (str, ''),
-        'name':   (str, ''),
-        'units':  ((str, asunits.core.UnitBase), ''),
+        'source': {'cls': str, 'def': ''},
+        'dim':    {'cls': str, 'def': ''},
+        'quant':  {'cls': str, 'def': ''},
+        'name':   {'cls': str, 'def': ''},
+        'units':  {'cls': (str, asunits.core.UnitBase), 'def': ''},
     },
     'dobj': {
     },
@@ -1100,12 +1100,12 @@ def _harmonize_params(
 
             # Set to default if None
             if v1.get(k0) is None:
-                dd[k1][k0] = v0[1]
+                dd[k1][k0] = v0['def']
 
             # Check type if already included
-            elif not isinstance(dd[k1][k0], v0[0]):
+            elif not isinstance(dd[k1][k0], v0['cls']):
                 dfail[k0] = (
-                    f" expected {v0[0]} vs "
+                    f" expected {v0['def']} vs "
                     f"type({dd_name2}['{k1}']['{k0}']) = {type(dd[k1][k0])}"
                 )
 

--- a/datastock/_saveload.py
+++ b/datastock/_saveload.py
@@ -71,20 +71,6 @@ def save(
         types=bool,
     )
 
-    # -----------------------
-    # store initial data type
-
-    dtypes = {
-        f'{k0}_type': v0.__class__.__name__
-        for k0, v0 in dflat.items()
-    }
-    dflat.update(dtypes)
-
-    # convert astropy units to str
-    for k0, v0 in dflat.items():
-        if isinstance(v0, asunits.core.UnitBase):
-            dflat[k0] = str(v0)
-
     # ----------------------
     # save / print / return
 
@@ -177,6 +163,8 @@ def load(
             dout[k0] = dflat[k0]
         elif 'Unit' in typ:
             dout[k0] = asunits.Unit(v0.tolist())
+        elif typ == 'type':
+            dout[k0] = dflat[k0]
         else:
             msg = (
                 f"Don't know how to deal with dflat['{k0}']: {typ}"


### PR DESCRIPTION
Main changes:
-----------------
* `to_dict(asarray=True, with_types=True, type_str=None)` implemented to control asarray in datastock instead of in np.savez()
* `_ddef` attribute now uses a subdict to avoid inhomogenous sequence

Issues:
-------
* Fixes issue #67 in devel