### PR TITLE
Issue073 interpolate common refs

### DIFF
--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -763,6 +763,8 @@ class DataStock1(DataStock0):
         x1=None,
         # domain limitations
         domain=None,
+        # common ref
+        ref_com=None,
         # parameters
         grid=None,
         deg=None,
@@ -783,6 +785,8 @@ class DataStock1(DataStock0):
             x1=x1,
             # domain limitations
             domain=domain,
+            # common ref
+            ref_com=ref_com,
             # parameters
             grid=grid,
             deg=deg,

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -377,11 +377,6 @@ def _check(
         dref_com=dref_com,
     )
 
-    k0 = list(ddata.keys())[0]
-    if ddata[k0].shape == (100, 39) and dsh_other[k0] == (80,):
-        import pdb; pdb.set_trace()     # DB
-        pass
-
     return (
         deg, deriv,
         kx0, kx1, x0, x1, refx, dref_com,

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -365,23 +365,69 @@ class Test02_Manipulate():
                 shape = tuple(np.r_[shape[:aa[0]], x0s, shape[aa[-1]+1:]])
             else:
                 shape = tuple(np.r_[x0s, 39]) if ii == 2 else None
+            if dout[kk]['data'].shape != tuple(shape):
+                msg = str(dout[kk]['data'].shape, shape, kk, rr)
+                raise Exception(msg)
+
+    def test11_interpolate_common_refs(self):
+        lk = ['3d', '3d', '3d', '3d']
+        lref = ['t0', ['nt0', 'nx'], ['nx']]
+        lrefc = ['nc', ['nc'], ['t0', 'nc']]
+        lax = [[0], [0, 1], [1], [1]]
+        llog = [False, True, False, True]
+
+        # add data for common ref interpolation
+        nt0 = self.st.dref['nt0']['size']
+        nc = self.st.dref['nc']['size']
+        self.st.add_data(
+            key='data_com',
+            data=np.random.random((nt0, nc),
+            ref=('nt0', 'nc'),
+        )
+
+        zipall = zip(lk, lref, lax, llog, lx0, lx1)
+        for ii, (kk, rr, aa, lg, x0, x1) in enumerate(zipall):
+
+            dout = self.st.interpolate(
+                keys=kk,
+                ref_key=rr,
+                x0='data_com',
+                x1=x1,
+                grid=False,
+                deg=2,
+                deriv=None,
+                log_log=lg,
+                return_params=False,
+                domain=None,
+                ref_com=ref_com,
+            )
+
+            assert isinstance(dout, dict)
+            assert isinstance(dout[kk]['data'], np.ndarray)
+            shape = list(self.st.ddata[kk]['data'].shape)
+            x0s = np.array(x0).shape if gg is False else (len(x0), len(x1))
+            if dom is None:
+                shape = tuple(np.r_[shape[:aa[0]], x0s, shape[aa[-1]+1:]])
+            else:
+                shape = tuple(np.r_[x0s, 39]) if ii == 2 else None
             assert dout[kk]['data'].shape == tuple(shape), (dout[kk]['data'].shape, shape, kk, rr)
+        pass
 
     # ------------------------
     #   Plotting
     # ------------------------
 
-    def test11_plot_as_array(self):
+    def test12_plot_as_array(self):
         dax = self.st.plot_as_array(key='t0')
         dax = self.st.plot_as_array(key='prof0')
         dax = self.st.plot_as_array(key='3d')
         plt.close('all')
 
-    def test12_plot_BvsA_as_distribution(self):
+    def test13_plot_BvsA_as_distribution(self):
         dax = self.st.plot_BvsA_as_distribution(keyA='prof0', keyB='prof0-bis')
         plt.close('all')
 
-    def test13_plot_as_profile1d(self):
+    def test14_plot_as_profile1d(self):
         dax = self.st.plot_as_profile1d(
             key='prof0',
             key_time='t0',
@@ -390,7 +436,7 @@ class Test02_Manipulate():
         )
         plt.close('all')
 
-    def test14_plot_as_mobile_lines(self):
+    def test15_plot_as_mobile_lines(self):
 
         # 3d
         dax = self.st.plot_as_mobile_lines(
@@ -413,7 +459,7 @@ class Test02_Manipulate():
     #   File handling
     # ------------------------
 
-    def test15_copy_equal(self):
+    def test16_copy_equal(self):
         st2 = self.st.copy()
         assert st2 is not self.st
 
@@ -421,10 +467,10 @@ class Test02_Manipulate():
         if msg is not True:
             raise Exception(msg)
 
-    def test16_get_nbytes(self):
+    def test17_get_nbytes(self):
         nb, dnb = self.st.get_nbytes()
 
-    def test17_saveload(self, verb=False):
+    def test18_saveload(self, verb=False):
         pfe = self.st.save(path=_PATH_OUTPUT, verb=verb, return_pfe=True)
         st2 = load(pfe, verb=verb)
         # Just to check the loaded version works fine

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -397,8 +397,6 @@ class Test02_Manipulate():
         zipall = zip(lk, lref, lax, llog, lx1, lrefc, ls, lr)
         for ii, (kk, rr, aa, lg, x1, refc, ss, ri) in enumerate(zipall):
 
-            print(ii+1)
-
             dout = self.st.interpolate(
                 keys=kk,
                 ref_key=rr,


### PR DESCRIPTION
Main changes:
-------------------
* `interpolate(ref_com=str)` implemented
* `ref_com` has to be the first or last `ref` of `x0`
* should with `domain` as long as they are not referring to the same `ref`
* unit tests ok for up to 2 dimensional, `domain` not tested