### PR TITLE
[#97] ds.get_files() implemented

### DIFF
--- a/datastock/__init__.py
+++ b/datastock/__init__.py
@@ -3,6 +3,6 @@
 from .version import __version__
 
 from ._class import DataStock
-from ._saveload import load
+from ._saveload import load, get_files
 from ._direct_calls import *
 from . import tests

--- a/datastock/_saveload.py
+++ b/datastock/_saveload.py
@@ -286,7 +286,6 @@ def get_files(
                     for p0 in patterns
                 ])
         ])
-        print(pfe)
     
     # ---------------------
     # format pfe into dpfe
@@ -327,7 +326,7 @@ def get_files(
             msg = (
                 "Arg dpath must be a dict with:\n"
                 "\t- keys: valid paths\n"
-                "\t- values: dict with 'patterns' xor 'pfe'"
+                "\t- values: dict with 'patterns' xor 'pfe'\n"
                 f"Provided:\n{dpath}"
             )
             raise Exception(msg)

--- a/datastock/_saveload.py
+++ b/datastock/_saveload.py
@@ -185,3 +185,159 @@ def load(
         print(msg)
 
     return obj
+
+
+# #################################################################
+# #################################################################
+#                   Find files
+# #################################################################
+
+
+def get_files(
+    path=None,
+    patterns=None,
+    pfe=None,
+    dpath=None,
+):
+    """ Return a dict of path keys associated to list of file names
+    
+    A pfe is a str describing the path, file name and extension
+    
+    If pfe is provided, it is just checked
+    
+    If path / patterns is provided, return all files in path matching patterns
+    
+    If dpath is provided, must be a dict with:
+        - keys: valid path
+        - values: dict with 'patterns' or 'pfe'
+    
+    """
+    
+    # ------
+    # pick
+
+    lc = [
+        pfe is not None,
+        patterns is not None,
+        dpath is not None,
+    ]    
+    
+    if np.sum(lc) != 1:
+        msg = "Please provide pfe xor pattern xor case!"
+        raise Exception(msg)
+
+    # -----------
+    # check path
+
+    if path is not None:
+        if not (isinstance(path, str) and os.path.isdir(path)):
+            msg = f"Arg path must be a valid path name!\n{path}"
+            return Exception(msg)
+    else:
+        path = './'
+    path = os.path.abspath(path)
+
+    # -----------
+    # check pfe
+    
+    if isinstance(pfe, str):
+        pfe = [pfe]
+
+    if pfe is not None:
+        
+        err = False
+        assert isinstance(pfe, (list, tuple))
+        lout = [pp for pp in pfe if not os.path.isfile(pp)]
+        
+        # check that each file exists
+        if len(lout) == len(pfe):
+            pfe = [os.path.join(path, pp) for pp in pfe]
+            lout = [pp for pp in pfe if not os.path.isfile(pp)]
+            if len(lout) > 0:
+                err = True
+        elif len(lout) > 0:
+            err = True
+            
+        # Exception
+        if err is True:
+            msg = f"The following files do not exist:\n{lout}"
+            raise Exception(msg)
+
+    # ---------------------------
+    # check pattern
+    
+    if patterns is not None:
+        
+        if isinstance(patterns, str):
+            patterns = [patterns]
+        
+        if not all([isinstance(pp, str) for pp in patterns]):
+            msg = f"Arg patterns must be a list of str!\n{patterns}"
+            raise Exception(msg)
+        
+        pfe = sorted([
+            os.path.join(path, ff) for ff in os.listdir(path)
+            if all([pp in ff for pp in patterns])
+        ])
+    
+    # ---------------------
+    # format pfe into dpfe
+    
+    if dpath is None:
+        
+        lpf = [os.path.split(ff) for ff in pfe]
+        lpu = sorted(set([ff[0] for ff in lpf]))
+        
+        dpfe = {
+            os.path.abspath(k0): [ff[1] for ff in lpf if ff[0] == k0]
+            for k0 in lpu
+        }
+    
+    # ----------------
+    # check case
+
+    if dpath is not None:
+        
+        # check format
+        c0 = (
+            isinstance(dpath, dict)
+            and all([
+                isinstance(k0, str)
+                and os.path.isdir(k0)
+                and (
+                    isinstance(v0, (str, list))
+                    or (
+                        isinstance(v0, dict)
+                        and isinstance(v0.get('patterns', ''), (list, str))
+                        and isinstance(v0.get('pfe', ''), (list, str))
+                    )
+                )
+                for k0, v0 in dpath.items()
+            ])
+        )
+        if not c0:
+            msg = (
+                "Arg dpath must be a dict with:\n"
+                "\t- keys: valid paths\n"
+                "\t- values: dict with 'patterns' xor 'pfe'"
+                f"Provided:\n{dpath}"
+            )
+            raise Exception(msg)
+        
+        # str => patterns
+        for k0, v0 in dpath.items():
+            if isinstance(v0, (str, list)):
+                dpath[k0] = {'patterns': v0}
+        
+        # append list of files
+        dpfe = {}
+        for k0, v0 in dpath.items():
+            
+            dpfe.update(get_files(
+                path=k0,
+                pfe=v0.get('pfe'),
+                patterns=v0.get('patterns'), 
+                dpath=None,
+            ))
+    
+    return dpfe   


### PR DESCRIPTION
Main changes:
----------------
* `ds.get_files()` implemented
```
def get_files(
    path=None,
    patterns=None,
    pfe=None,
    dpath=None,
):
    """ Return a dict of path keys associated to list of file names
    
    A pfe is a str describing the path, file name and extension
    
    If pfe is provided, it is just checked
    
    If path / patterns is provided, return all files in path matching patterns
    
    If dpath is provided, must be a dict with:
        - keys: valid path
        - values: dict with 'patterns' or 'pfe'
    
    """
```

Useful routine to quickly scan:
    - `path` / `pattern`: a  single folder looking for files matching (or excluding) a naming pattern
    - `dpath`: multiple folder looking for files matching (or excluding) folder-specific naming pattern

Result always returned as a `dict`.
Handles both relative and absolute paths (as input).
Returned dict always gives absolute paths.

Issues:
-------
* Fixes, in devel, issue #97 


Examples:
-----------


```
import datastock as ds
```

Can be used to search  single folder:
```
# looking for all files containing a single pattern
dpfe = ds.get_files(path='./', patterns='.py')

# looking for all files not containing a single pattern (use of tuple)
dpfe = ds.get_files(path='./', patterns=('.py',))

# looking for all files containing all listed patterns but excluding others
dpfe = ds.get_files(path='./', patterns=['pattern1', 'pattern2', '.py', ('nopattern1', 'nopattern2')])
```

Or multiple folder using the `dpath` argument:
```
# multiple folders
dpath = {
    './': '.py',
    '../': ['pattern1', 'py'],
    '~/': ['pattern1', (nopattern1,)] 
}
dpfe = ds.get_files(dpath=dpath)
```



