### PR TITLE
Issue105 generalize binning

### DIFF
--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -728,13 +728,13 @@ class DataStock1(DataStock0):
         bins1=None,
         bin_data0=None,
         bin_data1=None,
-        bin_units=None,
+        bin_units0=None,
         # kind of binning
         integrate=None,
         statistic=None,
         # options
         safety_ratio=None,
-        ref_vector_strategy=None,
+        dref_vector=None,
         store=None,
     ):
         """ Bin data along ref_key
@@ -759,12 +759,13 @@ class DataStock1(DataStock0):
             bins1=bins1,
             bin_data0=bin_data0,
             bin_data1=bin_data1,
-            bin_units=bin_units,
+            bin_units0=bin_units0,
             # kind of binning
             integrate=integrate,
             statistic=statistic,
             # options
-            safety_ratio=saftey_ratio,
+            safety_ratio=safety_ratio,
+            dref_vector=dref_vector,
             store=store,
         )
 

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -735,6 +735,8 @@ class DataStock1(DataStock0):
         # options
         safety_ratio=None,
         dref_vector=None,
+        verb=None,
+        returnas=None,
         # storing
         store=None,
         keys_store=None,
@@ -768,6 +770,8 @@ class DataStock1(DataStock0):
             # options
             safety_ratio=safety_ratio,
             dref_vector=dref_vector,
+            verb=verb,
+            returnas=returnas,
             # storing
             store=store,
             keys_store=keys_store,

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -720,10 +720,22 @@ class DataStock1(DataStock0):
 
     def binning(
         self,
-        keys=None,
-        ref_key=None,
-        bins=None,
+        data=None,
+        data_units=None,
+        axis=None,
+        # binning
+        bins0=None,
+        bins1=None,
+        bin_data0=None,
+        bin_data1=None,
+        bin_units=None,
+        # kind of binning
+        integrate=None,
+        statistic=None,
+        # options
+        safety_ratio=None,
         ref_vector_strategy=None,
+        store=None,
     ):
         """ Bin data along ref_key
 
@@ -739,10 +751,21 @@ class DataStock1(DataStock0):
 
         return _class1_binning.binning(
             coll=self,
-            keys=keys,
-            ref_key=ref_key,
-            bins=bins,
-            ref_vector_strategy=ref_vector_strategy,
+            data=data,
+            data_units=data_units,
+            axis=axis,
+            # binning
+            bins0=bins0,
+            bins1=bins1,
+            bin_data0=bin_data0,
+            bin_data1=bin_data1,
+            bin_units=bin_units,
+            # kind of binning
+            integrate=integrate,
+            statistic=statistic,
+            # options
+            safety_ratio=saftey_ratio,
+            store=store,
         )
 
     # ---------------------

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -739,7 +739,7 @@ class DataStock1(DataStock0):
         returnas=None,
         # storing
         store=None,
-        keys_store=None,
+        store_keys=None,
     ):
         """ Return the binned data
         
@@ -804,7 +804,7 @@ class DataStock1(DataStock0):
             returnas=returnas,
             # storing
             store=store,
-            keys_store=keys_store,
+            store_keys=store_keys,
         )
 
     # ---------------------

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -73,8 +73,8 @@ class DataStock1(DataStock0):
             'quant',
             'name',
             'units',
-            'source',
-            'monot',
+            # 'source',
+            # 'monot',
         ],
     }
 
@@ -741,15 +741,45 @@ class DataStock1(DataStock0):
         store=None,
         keys_store=None,
     ):
-        """ Bin data along ref_key
-
-        Binning is treated here as an integral
-        Hence, if:
-            - the data has units [ph/eV]
-            - the ref_key has units [eV]
-            - the binned data has units [ph]
-
-        return a dict with data and units per key
+        """ Return the binned data
+        
+        data:  the data on which to apply binning, can be
+            - a list of np.ndarray to be binned
+                (any dimension as long as they all have the same)
+            - a list of keys to ddata items sharing the same refs
+            
+        data_units: str only necessary if data is a list of arrays
+        
+        axis: int or array of int indices
+            the axis of data along which to bin
+            data will be flattened along all those axis priori to binning
+            If None, assumes bin_data is not variable and uses all its axis 
+        
+        bins0: the bins (centers), can be
+            - a 1d vector of monotonous bins
+            - a int, used to compute a bins vector from max(data), min(data)
+        
+        bin_data0: the data used to compute binning indices, can be:
+            - a str, key to a ddata item
+            - a np.ndarray
+            _ a list of any of the above if each data has different size along axis
+            
+        bin_units: str
+            only used if integrate = True and bin_data is a np.ndarray
+            
+        integrate: bool
+            flag indicating whether binning is used for integration
+            Implies that:
+                Only usable for 1d binning (axis has to be a single index)
+                data is multiplied by the underlying bin_data0 step prior to binning
+                
+        statistic: str
+            the statistic kwd feed to scipy.stats.binned_statistic()
+            automatically set to 'sum' if integrate = True
+            
+        store: bool
+            If True, will sotre the result in ddata
+            Only possible if all (data, bin_data and bin) are provided as keys
 
         """
 
@@ -803,6 +833,7 @@ class DataStock1(DataStock0):
         returnas=None,
         return_params=None,
         store=None,
+        store_keys=None,
         inplace=None,
     ):
         """ Interpolate keys in desired dimension
@@ -830,6 +861,7 @@ class DataStock1(DataStock0):
             returnas=returnas,
             return_params=return_params,
             store=store,
+            store_keys=store_keys,
             inplace=inplace,
         )
 

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -735,7 +735,9 @@ class DataStock1(DataStock0):
         # options
         safety_ratio=None,
         dref_vector=None,
+        # storing
         store=None,
+        keys_store=None,
     ):
         """ Bin data along ref_key
 
@@ -766,7 +768,9 @@ class DataStock1(DataStock0):
             # options
             safety_ratio=safety_ratio,
             dref_vector=dref_vector,
+            # storing
             store=store,
+            keys_store=keys_store,
         )
 
     # ---------------------

--- a/datastock/_class1_binning.py
+++ b/datastock/_class1_binning.py
@@ -573,7 +573,7 @@ def _check_bins(
     if bins is None:
         bins = 100
 
-    if np.isscalar(bins):
+    if np.isscalar(bins) and not isinstance(bins, str):
         bins = int(bins)
 
     elif isinstance(bins, str):

--- a/datastock/_class1_binning.py
+++ b/datastock/_class1_binning.py
@@ -10,6 +10,7 @@ import itertools as itt
 
 
 import numpy as np
+import astropy.units as asunits
 import scipy.stats as scpst
 
 
@@ -25,9 +26,18 @@ from . import _generic_check
 
 def binning(
     coll=None,
-    keys=None,
-    ref_key=None,
-    bins=None,
+    data=None,
+    data_units=None,
+    # binning
+    bins0=None,
+    bins1=None,
+    bin_data0=None,
+    bin_data1=None,
+    bin_units=None,
+    # kind of binning
+    integrate=None,
+    statistic=None,
+    # options
     safety_ratio=None,
     ref_vector_strategy=None,
 ):
@@ -39,52 +49,45 @@ def binning(
     # checks
 
     # keys
-    keys, ref_key, daxis, dunits, units_ref = _check_keys(
+    ddata, dbins0, dbins1, statistic = _check(
         coll=coll,
-        keys=keys,
-        ref_key=ref_key,
+        data=data,
+        data_units=data_units,
+        # binning
+        bins0=bins0,
+        bins1=bins1,
+        bin_data0=bin_data0,
+        bin_data1=bin_data1,
+        bin_units=bin_units,
+        # kind of binning
+        integrate=integrate,
+        statistic=statistic,
+        safety_ratio=safety_ratio,
+        strict=True,
+        # options
         only1d=True,
         ref_vector_strategy=ref_vector_strategy,
-    )
-
-    # because 1d only
-    ref_key = ref_key[0]
-    for k0, v0 in daxis.items():
-        daxis[k0] = v0[0]
-    units_ref = units_ref[0]
-
-    # bins
-    bins, units_bins, dv, _ = _check_bins(
-        coll=coll,
-        keys=keys,
-        ref_key=ref_key,
-        bins=bins,
-        vect=coll.ddata[ref_key]['data'],
-        strict=True,
-        safety_ratio=safety_ratio,
-    )
-
-    # units
-    dout = _units(
-        dunits=dunits,
-        units_ref=units_ref,
-        units_bins=units_bins,
     )
 
     # --------------
     # actual binning
 
-    for k0, v0 in dout.items():
-        dout[k0]['data'] = _bin(
-            bins=bins,
-            dv=dv,
-            vect=coll.ddata[ref_key]['data'],
-            data=coll.ddata[k0]['data'],
-            axis=daxis[k0],
-        )
-        ref = list(coll.ddata[k0]['ref'])
-        ref[daxis[k0]] = None
-        dout[k0]['ref'] = tuple(ref)
+    if dbins1 is None:
+
+        for k0, v0 in dout.items():
+            dout[k0]['data'] = _bin(
+                bins0=dbins0['edges'],
+                bins1=None if dbins1 is None else dbins1['edges'],
+                vect0=dbins0['data'],
+                vect1=dbins1['data'],
+                data=ddata[k0]['data'],
+                axis=dbins0['axis'],
+            )
+            ref = list(coll.ddata[k0]['ref'])
+            ref[daxis[k0]] = None
+            dout[k0]['ref'] = tuple(ref)
+
+    else:
 
     return dout
 
@@ -94,13 +97,26 @@ def binning(
 # ####################################
 
 
-def _check_keys(
+def _check(
     coll=None,
-    keys=None,
-    ref_key=None,
-    only1d=None,
+    data=None,
+    data_units=None,
+    # binning
+    bins0=None,
+    bins1=None,
+    bin_data0=None,
+    bin_data1=None,
+    bin_units0=None,
+    # kind of binning
+    integrate=None,
+    statistic=None,
+    # options
+    safety_ratio=None,
     ref_vector_strategy=None,
 ):
+
+    # ---------------
+    # nb of dim
 
     # only1d
     only1d = _generic_check._check_var(
@@ -111,121 +127,155 @@ def _check_keys(
 
     maxd = 1 if only1d else 2
 
-    # ---------------
-    # keys vs ref_key
-
-    # ref_key
-    if ref_key is not None:
-
-        # basic checks
-        if isinstance(ref_key, str):
-            ref_key = (ref_key,)
-
-        lref = list(coll.dref.keys())
-        ldata = list(coll.ddata.keys())
-
-        ref_key = list(_generic_check._check_var_iter(
-            ref_key, 'ref_key',
-            types=(list, tuple),
-            types_iter=str,
-            allowed=lref + ldata,
-        ))
-
-        # check vs maxd
-        if len(ref_key) > maxd:
-            msg = (
-                f"Arg ref_key shall have no more than {maxd} elements!\n"
-                f"Provided: {ref_key}"
-            )
-            raise Exception(msg)
-
-        # check vs valid vectors
-        for ii, rr in enumerate(ref_key):
-            if rr in lref:
-                kwd = {'ref': rr}
-            else:
-                kwd = {'key': rr}
-            hasref, hasvect, ref, ref_key[ii] = coll.get_ref_vector(
-                **kwd,
-            )[:4]
-
-            if not (hasref and hasvect):
-                msg = (
-                    f"Provided ref_key[{ii}] not a valid ref or ref vector!\n"
-                    "Provided: {rr}"
-                )
-                raise Exception(msg)
-
-        lok_keys = [
-            k0 for k0, v0 in coll.ddata.items()
-            if all([coll.ddata[rr]['ref'][0] in v0['ref'] for rr in ref_key])
-        ]
-
-        if keys is None:
-            keys = lok_keys
-    else:
-        lok_keys = list(coll.ddata.keys())
-
-    # keys
-    if isinstance(keys, str):
-        keys = [keys]
-
-    keys = _generic_check._check_var_iter(
-        keys, 'keys',
-        types=list,
-        types_iter=str,
-        allowed=lok_keys,
+    # integrate
+    integrate = _generic_check._check_var(
+        integrate, 'integrate',
+        types=bool,
+        default=False,
     )
 
-    # ref_key
-    if ref_key is None:
-        hasref, ref, ref_key, val, dkeys = coll.get_ref_vector_common(
-            keys=keys,
-            strategy=ref_vector_strategy,
+    # safety checks
+    if integrate is True and bin_data1 is not None:
+        msg = (
+            "If integrate = True, can only provide one bin dimension!"
         )
-        if ref_key is None:
-            msg = (
-                f"No matching ref vector found for:\n"
-                f"\t- keys: {keys}\n"
-                f"\t- hasref: {hasref}\n"
-                f"\t- ref: {ref}\n"
-                f"\t- ddata['{keys[0]}']['ref'] = {coll.ddata[keys[0]]['ref']} "
-            )
+        raise Exception(msg)
+
+    # statistic
+    if integrate is True:
+        statistic = 'sum'
+    else:
+        statistic = _generic_check._check_var(
+            statistic, 'statistic',
+            types=str,
+            default='sum',
+        )
+
+    # ------------------
+    # data: str vs array
+
+    # make sure it's a list
+    if isinstance(data, (np.ndarray, str)):
+        data = [data]
+    assert isinstance(data, list)
+
+    # identify case: str vs array
+    lc = [
+        all([
+            isinstance(dd, str)
+            and dd in coll.ddata.keys()
+            and coll.ddata[dd]['ref'] == coll.ddata[data[0]]['ref']
+            for dd in ddata
+        ]),
+        all([isinstance(dd, np.ndarray) and dd.shape == data[0].shape]),
+    ]
+
+    # if none => err
+    if np.sum(lc) != 1:
+        msg = (
+            "Arg data must be a list of either:\n"
+            "\t- keys to ddata with identical ref\n"
+            "\t- np.ndarrays with identical shape\n"
+            f"Provided:\n{data}"
+        )
+        raise Exception(msg)
+
+    # str => keys to existing data
+    if lc[0]:
+        ddata = {
+            k0: {
+                'key': k0,
+                'data': coll.ddata[k0]['data'],
+                'ref': coll.ddata[k0]['ref'],
+                'units': coll.ddata[k0]['units'],
+            }
+            for k0 in data
+        }
+
+    # arrays
+    else:
+        ddata = {
+            ii: {
+                'key': None,
+                'data': data[ii],
+                'ref': None,
+                'units': data_units,
+            }
+            for ii in range(len(data))
+        }
+
+    # -----------
+    # bins
+
+    # dbins0
+    dbins0, _ = _check_bins(
+        coll=coll,
+        dref=dref,
+        key_diag=key_diag,
+        dref_cam=dref_cam,
+        key_cam=key_cam,
+        bin_data=bin_data0,
+        bins=bins0,
+        bin_units=bins_units0,
+    )
+
+    # dbins1
+    if bin_data1 is not None:
+        dbins1, _ = _check_bins(
+            coll=coll,
+            dref=dref,
+            dref_cam=dref_cam,
+            key_diag=key_diag,
+            key_cam=key_cam,
+            bin_data=bin_data1,
+            bins=bins1,
+        )
+    else:
+        dbins1 = None
+
+    # -----------------------
+    # additional safety check
+
+    if integrate is True:
+
+        if dbins0['data'].ndim > 1:
+            msg = "Binned integration => only 1d bin_data usable"
             raise Exception(msg)
-        ref_key = (ref_key,)
 
-    # ------------------------
-    # daxis, dunits, units_ref
+        for k0, v0 in ddata.items():
+            dv = np.diff(dbins0['data'])
+            dv = np.r_[dv[0], dv]
 
-    # daxis
-    daxis = {
-        k0: [
-            coll.ddata[k0]['ref'].index(coll.ddata[rr]['ref'][0])
-            for rr in ref_key
-        ]
-        for k0 in keys
-    }
+            # reshape
+            if v0['data'].ndim > 1:
+                shape_dv = [
+                    -1 if ii == axis[0] for ii in range(v0['data'].shape)
+                ]
+                dv = dv.reshape(shape_dv)
 
-    # dunits
-    dunits = {k0: coll.ddata[k0]['units'] for k0 in keys}
+            ddata[k0]['data'] = v0['data'] * dv
+            ddata[k0]['units'] = v0['units'] * dbins0['units']
 
-    # units_ref
-    units_ref = [coll.ddata[rr]['units'] for rr in ref_key]
-
-    return keys, ref_key, daxis, dunits, units_ref
+    return ddata, dbins0, dbins1, statistic
 
 
 def _check_bins(
     coll=None,
-    keys=None,
-    ref_key=None,
+    dref=None,
+    dref_cam=None,
+    key_diag=None,
+    key_cam=None,
+    bin_data=None,
     bins=None,
-    vect=None,
-    safety_ratio=None,
+    bin_units=None,
     # if bsplines
+    safety_ratio=None,
     strict=None,
     deg=None,
 ):
+
+    # --------------
+    # options
 
     # check
     strict = _generic_check._check_var(
@@ -242,100 +292,164 @@ def _check_bins(
         sign='>0.'
     )
 
-    # ---------
+    # --------------
     # bins
 
-    if isinstance(bins, str):
-        lok = [k0 for k0, v0 in coll.ddata.items() if v0['monot'] == (True,)]
-        bins = _generic_check._check_var(
-            bins, 'bins',
-            types=str,
-            allowed=lok,
-        )
+    if bins is None:
+        bins = 100
 
-        bins_units = coll.ddata[bins]['units']
-        bins = coll.ddata[bins]['data']
+    if np.isscalar(bins):
+        bins = int(bins)
 
     else:
-        bins_units = None
+        bins = ds._generic_check._check_flat1d_array(
+            bins, 'bins',
+            dtype=float,
+            unique=True,
+            can_be_None=False,
+        )
 
-    bins = _generic_check._check_flat1darray(
-        bins, 'bins',
-        dtype=float,
+    # -------------
+    # bin data
+
+    if isinstance(bin_data, str):
+
+        lquant = ['etendue', 'amin', 'amax']  # 'los'
+        lcomp = ['length', 'tangency radius', 'alpha']
+        llamb = ['lamb', 'lambmin', 'lambmax', 'dlamb', 'res']
+        lok_fixed = ['x0', 'x1'] + lquant + lcomp + llamb
+
+        lok_sig_static = []
+        lok_sig_var = []
+        for k0 in coll.dobj['diagnostic'][key_diag]['signal']:
+            cams = coll.dobj['synth sig'][k0]['camera']
+            ref = coll.ddata[coll.dobj['synth sig'][k0]['data'][0]]['ref']
+            if ref == dref_cam[cams[0]]:
+                lok_sig_static.append(k0)
+            elif ref == dref[cams[0]]:
+                lok_sig_var.append(k0)
+
+        bin_key = ds._generic_check._check_var(
+            bin_data, 'bin_data',
+            types=str,
+            allowed=lok_fixed + lok_sig_static + lok_sig_var,
+        )
+        bin_data = coll.ddata[bin_key]['data']
+        bin_ref = coll.ddata[bin_key]['ref']
+        bin_units = coll.ddata[bin_key]['units']
+
+        variable = bin_data in lok_sig_var
+
+    elif isinstance(bin_data, np.ndarray):
+        bin_key = None
+        shape = tuple([ss for ss in data_shape if ss in bin_data.shape])
+        if bin_data.shape != shape:
+            msg = "Arg bin_data must have "
+            raise Exception(msg)
+
+    elif bin_data is None:
+        hasref, ref, bin_data, val, dkeys = coll.get_ref_vector_common(
+            keys=keys,
+            strategy=ref_vector_strategy,
+        )
+        if bin_data is None:
+            msg = (
+                f"No matching ref vector found for:\n"
+                f"\t- keys: {keys}\n"
+                f"\t- hasref: {hasref}\n"
+                f"\t- ref: {ref}\n"
+                f"\t- ddata['{keys[0]}']['ref'] = {coll.ddata[keys[0]]['ref']} "
+            )
+            raise Exception(msg)
+
+    else:
+        msg = f"Invalid bin_data:\n{bin_data}"
+        raise Exception(msg)
+
+    # ----------------
+    # get axis
+
+    if axis is None:
+        if bin_key is None:
+            axis = np.array([
+                ii for ii, ss in enumerate(data_shape)
+                if ss in bin_data.shape
+            ])
+        else:
+            axis = np.array([
+                ii for ii, rr in enumerate(data_ref)
+                if rr in bin_ref
+            ])
+
+    axis = ds._generic_check._check_flat1d_array(
+        axis, 'axis',
+        dtype=int,
         unique=True,
         can_be_None=False,
+        sign='>=0',
     )
 
-    # -----------------
-    # check uniformity
-
-    db = np.abs(np.diff(bins))
-    if not np.allclose(db[0], db):
-        msg = (
-            "Arg bins must be a uniform bin edges vector!"
-            f"Provided diff(bins) = {db}"
-        )
+    if np.any(axis > len(data_shape)-1):
+        msg = f"axis too large\n{axis}"
         raise Exception(msg)
-    db = db[0]
+
+    if np.any(np.diff(axis) > 1):
+        msg = f"axis must be adjacent indices!\n{axis}"
+        raise Exception(msg)
+
+    # --------------
+    # bins
+
+    # bins
+    if isinstance(bins, int):
+        bin_min = np.nanmin(bin_data)
+        bin_max = np.nanmax(bin_data)
+        bin_edges = np.linspace(bin_min, bin_max, bins + 1)
+
+    else:
+        bin_edges = np.r_[
+            bins[0] - 0.5*(bins[1] - bins[0]),
+            0.5*(bins[1:] + bins[:-1]),
+            bins[-1] + 0.5*(bins[-1] - bins[-2]),
+        ]
 
     # ----------
     # bin method
 
-    dv = np.abs(np.diff(vect))
-    dv = np.append(dv, dv[-1])
-    dvmean = np.mean(dv) + np.std(dv)
+    if bin_data.ndim == 1:
+        dv = np.abs(np.diff(bin_data))
+        dv = np.append(dv, dv[-1])
+        dvmean = np.mean(dv) + np.std(dv)
 
-    if strict is True:
-        lim = safety_ratio*dvmean
-        if not db > lim:
-            msg = (
-                f"Uncertain binning for '{sorted(keys)}', ref vect '{ref_key}':\n"
-                f"Binning steps ({db}) are < {safety_ratio}*ref ({lim}) vector step"
-            )
-            raise Exception(msg)
+        if strict is True:
+            lim = safety_ratio*dvmean
+            if not np.mean(np.diff(bin_edges)) > lim:
+                msg = (
+                    f"Uncertain binning for '{sorted(keys)}', ref vect '{ref_key}':\n"
+                    f"Binning steps ({db}) are < {safety_ratio}*ref ({lim}) vector step"
+                )
+                raise Exception(msg)
 
-        else:
-            npts = None
-
-    else:
-        npts = (deg + 3) * max(1, dvmean / db)
-
-    return bins, bins_units, dv, npts
-
-
-def _units(
-    dunits=None,
-    units_ref=None,
-    units_bins=None,
-):
-
-    dout = {}
-    for k0, v0 in dunits.items():
-        if v0 in [None, '']:
-            dout[k0] = {'units': ''}
-
-        elif units_ref in [None, ''] and units_bins in [None, '']:
-            dout[k0] = {'units': ''}
-
-        elif units_ref in [None, '']:
-            dout[k0] = {'units': v0 * units_bins}
-
-        elif units_bins in [None, '']:
-            dout[k0] = {'units': v0 * units_ref}
-
-        elif units_ref == units_bins:
-            dout[k0] = {'units': v0 * units_ref}
+            else:
+                npts = None
 
         else:
-            msg = (
-                f"Units do not agree between ref vector and bins for '{k0}'!\n"
-                f"\t- units     : {v0}\n"
-                f"\t- units_ref : {units_ref}\n"
-                f"\t- units_bins: {units_bins}\n"
-            )
-            raise Exception(msg)
+            npts = (deg + 3) * max(1, dvmean / db)
 
-    return dout
+    # ----------
+    # dbins
+
+    dbins = {
+        'key': bin_key,
+        'bins': bins,
+        'edges': edges,
+        'data': bin_data,
+        'ref': bin_ref,
+        'units': bin_units,
+        'axis': axis,
+    }
+
+    return dbins, npts
 
 
 # ####################################
@@ -345,25 +459,30 @@ def _units(
 
 
 def _bin(
-    bins=None,
-    dv=None,
-    vect=None,
     data=None,
+    vect0=None,
+    vect1=None,
+    bins0=None,
+    bins1=None,
     axis=None,
+    # integration
+    integrate=None,
+    dv=None,
 ):
 
     # ----------------------------
     # select only relevant indices
 
-    indin = (vect >= bins[0]) & (vect < bins[-1])
-
-    # shape
-    shape = list(data.shape)
-    shape[axis] = int(bins.size - 1)
-    val = np.zeros(tuple(shape), dtype=data.dtype)
+    indin = np.isfinite(vect0)
+    indin[indin] = (vect0[indin] >= bins[0]) & (vect0[indin] < bins[-1])
 
     # -------------
-    # safety check
+    # prepare shape
+
+    shape_data = data.shape
+    shape_other = [ss for ii, ss in shape_data if ii not in axis]
+    shape_val = tuple(list(shape_other).insert(axis[0], int(bins.size - 1)))
+    val = np.zeros(shape_val, dtype=data.dtype)
 
     if not np.any(indin):
         return val
@@ -372,44 +491,52 @@ def _bin(
     # subset
 
     # vect, dv
-    vect = vect[indin]
-    dv = dv[indin]
+    vect0 = vect0[indin]
 
     # data
-    sli = tuple([
-        indin if ii == axis else slice(None)
-        for ii in range(data.ndim)
-    ])
+    sli = tuple([slice(None) for ii in shape_other].insert(axis[0], indin))
     data = data[sli]
+
+    # integrate
+    if integrate is True:
+        if vect0.shape != data0.shape:
+            # reshape dv
+            shape_dv = [
+                ss if ii in axis else 1
+                for ii, ss in enumerate(shape_data)
+            ]
+            dv = dv.reshape(dvshape)
+
+        data = data * dv[indin]
 
     # ------------
     # dim == 1
 
     if data.ndim == 1:
 
-        val = scpst.binned_statistic(
-            vect,
-            data * dv,
-            bins=bins,
-            statistic=np.nansum,
-        )[0]
+        if dbins1 is None:
+            val = scpst.binned_statistic(
+                vect,
+                data,
+                bins=dbins0['edges'],
+                statistic=statistic,
+            )[0]
 
-    # ------------
-    # dim > 1
+        else:
+            val = scpst.binned_statistic_2d(
+                vect,
+                data,
+                bins=bins,
+                statistic=statistic,
+            )[0]
 
-    else:
+    # ---------------------------------
+    # data dim > 1 but vect dim minimal
 
-        # shape
-        shape_other = np.r_[shape[:axis], shape[axis+1:]].astype(int)
-
-        # reshape dv
-        dvshape = [-1 if ii == axis else 1 for ii in range(len(shape))]
-        dv = dv.reshape(dvshape)
+    elif vect.ndim == 1:
 
         # indices
         linds = [range(nn) for nn in shape_other]
-        indi = list(range(data.ndim-1))
-        indi.insert(axis, None)
 
         # get indices
         ind0 = np.searchsorted(
@@ -422,31 +549,34 @@ def _bin(
 
         # ind
         indu = np.unique(ind0 - 1)
-        
+
         # cases
         if indu.size == 1:
-            sli = tuple([
-                indu[0] if ii == axis else slice(None)
-                for ii in range(data.ndim)
-            ])
-            val[sli] = np.nansum(data*dv, axis=axis)
+            sli[axis[0]] = indu[0]
+            val[sli] = np.nansum(data, axis=axis)
 
         elif indu.size > 1:
 
-            sli = tuple([
-                indu if ii == axis else slice(None)
-                for ii in range(data.ndim)
-            ])            
+            sli[axis[0]] = indu
 
             # neutralize nans
             data[np.isnan(data)] = 0.
             ind = np.r_[0, np.where(np.diff(ind0))[0] + 1]
 
             # sum
-            val[sli] = np.add.reduceat(data*dv, ind, axis=axis)
+            val[sli] = np.add.reduceat(data, ind, axis=axis)
 
         else:
             import pdb; pdb.set_trace()     # DB
             pass
+
+    # -----------------------------
+    # data and vect have same shape
+
+    else:
+        assert data.shape == vect.shape
+
+
+
 
     return val

--- a/datastock/_class1_binning.py
+++ b/datastock/_class1_binning.py
@@ -350,7 +350,11 @@ def _check(
 
         for k0, v0 in ddata.items():
             
-            dv = np.diff(dbins0[k0]['data'], axis=axbin)
+            ddata[k0]['units'] = v0['units'] * dbins0[k0]['units']
+            if dbins0[k0]['data'].size == 0:
+                continue
+                
+            dv = np.diff(dbins0[k0]['data'], axis=axbin)           
             dv = np.concatenate(
                 (np.take(dv, [0], axis=axbin), dv),
                 axis=axbin,
@@ -368,7 +372,6 @@ def _check(
                     raise NotImplementedError()
 
             ddata[k0]['data'] = v0['data'] * dv
-            ddata[k0]['units'] = v0['units'] * dbins0[k0]['units']
 
     # --------
     # variability dict
@@ -959,7 +962,7 @@ def _bin_fixed_bin(
         # cases
         if indu.size == 1:
             sli[axis[0]] = indu[0]
-            val[sli] = np.nansum(data, axis=axis)
+            val[sli] = np.nansum(data, axis=axis[0])
 
         else:
 
@@ -1070,9 +1073,6 @@ def _store(
     # store
     
     for ii, (k0, v0) in enumerate(dout.items()):
-        
-        print(k0, store_keys[ii], v0['data'].shape, v0['ref'], v0['units'])
-        
         coll.add_data(
             key=store_keys[ii],
             data=v0['data'],

--- a/datastock/_class1_binning.py
+++ b/datastock/_class1_binning.py
@@ -55,7 +55,7 @@ def binning(
     returnas=None,
     # storing
     store=None,
-    keys_store=None,
+    store_keys=None,
 ):
     """ Return the binned data
     
@@ -164,7 +164,7 @@ def binning(
         _store(
             coll=coll,
             dout=dout,
-            keys_store=keys_store,
+            store_keys=store_keys,
         )
 
     # -------------
@@ -1046,20 +1046,20 @@ def _bin_fixed_bin(
 def _store(
     coll=None,
     dout=None,
-    keys_store=None,
+    store_keys=None,
 ):
 
 
     # ----------------
-    # check keys_store
+    # check store_keys
     
-    if len(dout) == 1 and isinstance(keys_store, str):
-        keys_store = [keys_store]
+    if len(dout) == 1 and isinstance(store_keys, str):
+        store_keys = [store_keys]
     
     ldef = [f"{k0}_binned" for k0 in dout.items()]
     lex = list(coll.ddata.keys())
-    keys_store = _generic_check._check_var_iter(
-        keys_store, 'keys_store',
+    store_keys = _generic_check._check_var_iter(
+        store_keys, 'store_keys',
         types=list,
         types_iter=str,
         default=ldef,
@@ -1071,10 +1071,10 @@ def _store(
     
     for ii, (k0, v0) in enumerate(dout.items()):
         
-        print(k0, keys_store[ii], v0['data'].shape, v0['ref'], v0['units'])
+        print(k0, store_keys[ii], v0['data'].shape, v0['ref'], v0['units'])
         
         coll.add_data(
-            key=keys_store[ii],
+            key=store_keys[ii],
             data=v0['data'],
             ref=v0['ref'],
             units=v0['units'],

--- a/datastock/_class1_binning.py
+++ b/datastock/_class1_binning.py
@@ -984,8 +984,9 @@ def _bin_fixed_bin(
         linds = [range(nn) for nn in shape_other]
         
         # slice_data
-        sli = np.array([0 for ii in shape_other])
-        sli = np.insert(sli, axis[0], slice(None))
+        sli = [0 for ii in shape_other]
+        sli.insert(axis[0], slice(None))
+        sli = np.array(sli)
         
         if bins1 is None:
             

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -45,6 +45,7 @@ def interpolate(
     return_params=None,
     returnas=None,
     store=None,
+    store_keys=None,
     inplace=None,
     # debug or unit tests
     debug=None,
@@ -152,6 +153,7 @@ def interpolate(
             coll=coll,
             dout=dout,
             inplace=inplace,
+            store_keys=store_keys,
         )
 
     # -------
@@ -1572,6 +1574,7 @@ def _store(
     coll=None,
     dout=None,
     inplace=None,
+    store_keys=None,
 ):
 
     # -----------
@@ -1586,17 +1589,31 @@ def _store(
         ])))
         coll2 = coll.extract(keys=ldata, vectors=True)
 
+    # -------------
+    # store_keys
+    
+    if store_keys is None:
+        store_keys = [f"{k0}_interp" for k0 in dout.keys()]
+    if isinstance(store_keys, str):
+        store_keys = [store_keys]
+    
+    lout = list(coll.ddata.keys())
+    store_keys = _generic_check._check_var_iter(
+        store_keys, 'store_keys',
+        types=list,
+        types_iter=str,
+        excluded=lout,
+    )
+    
+    assert len(store_keys) == len(dout)
+
     # ---------
     # add data
 
-    for k0, v0 in dout.items():
+    for ii, (k0, v0) in enumerate(dout.items()):
 
-        # ---------
-        # populate
-
-        # data
         coll2.add_data(
-            key=f'{k0}_interp',
+            key=store_keys[ii],
             data=v0['data'],
             ref=v0['ref'],
             units=v0['units'],

--- a/datastock/_generic_utils.py
+++ b/datastock/_generic_utils.py
@@ -590,3 +590,44 @@ def reshape_dict(din, sep=None):
     for k0, v0 in din.items():
         _reshape_dict(k0, v0, dinit=dout, sep=sep)
     return dout
+
+
+# ########################################################################
+# ########################################################################
+#            Find all indices of a subsequence in sequence
+# ########################################################################
+
+
+def KnuthMorrisPratt(text, pattern):
+
+    """ Yields all starting positions of copies of the pattern in the sequence
+    
+    Calling conventions are similar to string.find, but its arguments can be
+    lists or iterators, not just strings, it returns all matches, not just
+    the first one, and it does not need the whole text in memory at once.
+    Whenever it yields, it will have read the text exactly up to and including
+    the match that caused the yield.
+    """
+
+    # allow indexing into pattern and protect against change during yield
+    pattern = list(pattern)
+
+    # build table of shift amounts
+    shifts = [1] * (len(pattern) + 1)
+    shift = 1
+    for pos in range(len(pattern)):
+        while shift <= pos and pattern[pos] != pattern[pos-shift]:
+            shift += shifts[pos-shift]
+        shifts[pos+1] = shift
+
+    # do the actual search
+    startPos = 0
+    matchLen = 0
+    for c in text:
+        while matchLen == len(pattern) or \
+              matchLen >= 0 and pattern[matchLen] != c:
+            startPos += shifts[matchLen]
+            matchLen -= shifts[matchLen]
+        matchLen += 1
+        if matchLen == len(pattern):
+            yield startPos

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -323,7 +323,7 @@ class Test02_Manipulate():
                 axis=ax,
                 integrate=integ,
                 store=store,
-                keys_store=kbin,
+                store_keys=kbin,
                 safety_ratio=0.95,
                 returnas=True,
             )

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -306,23 +306,44 @@ class Test02_Manipulate():
 
         bins = np.linspace(1, 5, 10)
         lk = [
-            ('y', 'nx', 0),
-            ('prof0', 'nt0', 0),
-            ('prof0', 'x', 1),
+            ('y', 'nx', bins, 0, False, False, 'y_bin0'),
+            ('y', 'nx', bins, 0, True, False, 'y_bin1'),
+            ('y', 'nx', 'x', 0, False, True, 'y_bin2'),
+            ('y', 'nx', 'x', 0, True, True, 'y_bin3'),
+            ('prof0', 'x', 'nt0', 0, False, True, 'p0_bin0'),
+            ('prof0', 'x', 'nt0', 0, True, True, 'p0_bin1'),
+            ('prof1', 'x', 'prof0', [0, 1], False, True, 'p1_bin0'),
         ]
 
-        for (k0, kr, ax) in lk:
+        for ii, (k0, kr, kb, ax, integ, store, kbin) in enumerate(lk):
             dout = self.st.binning(
                 data=k0,
                 bin_data0=kr,
-                bins0=bins,
+                bins0=kb,
                 axis=ax,
+                integrate=integ,
+                store=store,
+                keys_store=kbin,
             )
+            
+            if np.isscalar(ax):
+                ax = [ax]
 
+            nb = self.st.ddata[kb]['data'].size if isinstance(kb, str) else bins.size
             k0 = list(dout.keys())[0]
-            shape = list(self.st.ddata[k0]['data'].shape)
-            shape[ax] = bins.size
-            assert dout[k0]['data'].shape == tuple(shape)
+            shape = [
+                ss for ii, ss in enumerate(self.st.ddata[k0]['data'].shape)
+                if ii not in ax
+            ]
+
+            shape.insert(ax[0], nb)
+            if dout[k0]['data'].shape != tuple(shape):
+                msg = (
+                    "Mismatching shapes for case {ii}!\n"
+                    f"\t- dout['{k0}']['data'].shape = {dout[k0]['data'].shape}\n"
+                    f"\t- expected: {tuple(shape)}"
+                )
+                raise Exception(msg)
 
     def test10_interpolate(self):
 

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -304,15 +304,15 @@ class Test02_Manipulate():
 
     def test09_binning(self):
 
-        bins = np.linspace(1, 5, 10)
+        bins = np.linspace(1, 5, 8)
         lk = [
             ('y', 'nx', bins, 0, False, False, 'y_bin0'),
             ('y', 'nx', bins, 0, True, False, 'y_bin1'),
             ('y', 'nx', 'x', 0, False, True, 'y_bin2'),
             ('y', 'nx', 'x', 0, True, True, 'y_bin3'),
-            ('prof0', 'x', 'nt0', 0, False, True, 'p0_bin0'),
-            ('prof0', 'x', 'nt0', 0, True, True, 'p0_bin1'),
-            ('prof1', 'x', 'prof0', [0, 1], False, True, 'p1_bin0'),
+            ('prof0', 'x', 'nt0', 1, False, True, 'p0_bin0'),
+            ('prof0', 'x', 'nt0', 1, True, True, 'p0_bin1'),
+            ('prof0-bis', 'prof0', 'x', [0, 1], False, True, 'p1_bin0'),
         ]
 
         for ii, (k0, kr, kb, ax, integ, store, kbin) in enumerate(lk):
@@ -324,12 +324,21 @@ class Test02_Manipulate():
                 integrate=integ,
                 store=store,
                 keys_store=kbin,
+                safety_ratio=0.95,
+                returnas=True,
             )
             
             if np.isscalar(ax):
                 ax = [ax]
 
-            nb = self.st.ddata[kb]['data'].size if isinstance(kb, str) else bins.size
+            if isinstance(kb, str):
+                if kb in self.st.ddata:
+                    nb = self.st.ddata[kb]['data'].size
+                else:
+                    nb = self.st.dref[kb]['size']
+            else:
+                nb = bins.size
+
             k0 = list(dout.keys())[0]
             shape = [
                 ss for ii, ss in enumerate(self.st.ddata[k0]['data'].shape)

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -306,23 +306,22 @@ class Test02_Manipulate():
 
         bins = np.linspace(1, 5, 10)
         lk = [
-            ('y', None, 0),
             ('y', 'nx', 0),
-            (None, 'nt0', 0),
             ('prof0', 'nt0', 0),
             ('prof0', 'x', 1),
         ]
 
         for (k0, kr, ax) in lk:
             dout = self.st.binning(
-                keys=k0,
-                ref_key=kr,
-                bins=bins,
+                data=k0,
+                bin_data0=kr,
+                bins0=bins,
+                axis=ax,
             )
 
             k0 = list(dout.keys())[0]
             shape = list(self.st.ddata[k0]['data'].shape)
-            shape[ax] = bins.size - 1
+            shape[ax] = bins.size
             assert dout[k0]['data'].shape == tuple(shape)
 
     def test10_interpolate(self):


### PR DESCRIPTION
Main chnages:
----------------
* `binning()` now:
    - requires `axis` as input (or default to all dimensions => flattened arrays)
    - can handle known keys for `data`, `bin_data` and `bins`
    - can handle npndarrays for `data`, `bin_data` and `bins`
    - can hande 1d and 2d binning
    - can handle binning for any dimensions (flattened along `axis` = list of indices used for binning)
    - can handle binning for any dimension of `data` and `bin_data` (flattened)
    - can hande binning for  any dimension of `data` (non-flat) provided `bin_data` is not time-varying (flattened)
    - can be used for simple binning or for integration (`integrate=True`)
* if `store=True`, all `data`, `bin_data` and `bins` have to be keys to known items