### PR TITLE
[#111] Better error msg

### DIFF
--- a/datastock/_plot_as_array.py
+++ b/datastock/_plot_as_array.py
@@ -412,10 +412,18 @@ def _check_keyXYZ(
                         or _check_uniform_log(k0=k0, ddata=coll._ddata)
                     ]
 
-                keyX = _generic_check._check_var(
-                    keyX, 'keyX',
-                    allowed=lok,
-                )
+                try:
+                    keyX = _generic_check._check_var(
+                        keyX, keyXstr,
+                        allowed=lok,
+                    )
+                except Exception as err:
+                    msg = (
+                        err.args[0]
+                        + f"\nContraint on uniformity: {uniform}"
+                    )
+                    err.args = (msg,)
+                    raise err
 
                 refX = coll._ddata[keyX]['ref'][0]
 


### PR DESCRIPTION
Main changes:
-----------------
* Better error msg for `plot_as_array()` when choosing `keyX`, `keyY`, `keyZ`...

Issues:
---------
Fixes, in devel, issue #111 