### PR TITLE
Basics for future Deriv2d implementation

### DIFF
--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -533,14 +533,6 @@ def _check_params(
     # ----
     # ndim
 
-    if deriv not in [None, 0] and ndim > 1:
-        msg = (
-            "Arg deriv can only be used for 1d interpolations!\n"
-            f"\t- ndim: {ndim}\n"
-            f"\t- deriv: {deriv}\n"
-        )
-        raise Exception(msg)
-
     if ndim > 2:
         msg = (
             "Interpolations of more than 2 dimensions not implemented!\n"
@@ -551,12 +543,24 @@ def _check_params(
     # -----
     # deriv
 
-    deriv = _generic_check._check_var(
-        deriv, 'deriv',
-        default=0,
-        types=int,
-        allowed=[ii for ii in range(deg + 1)],
-    )
+    if ndim == 1:
+        deriv = _generic_check._check_var(
+            deriv, 'deriv',
+            default=0,
+            types=int,
+            allowed=[ii for ii in range(deg + 1)],
+        )
+
+    elif ndim == 2:
+
+        deriv = tuple(_generic_check._check_var_iter(
+            deriv, 'deriv',
+            default=(0, 0),
+            types=(list, tuple),
+            types_iter=int,
+            size=2,
+            allowed=[ii for ii in range(deg + 1)],
+        ))
 
     # -------
     # log_log
@@ -1518,6 +1522,8 @@ def _interp2d(
                 )(
                     np.log(x0[slix]),
                     np.log(x1[slix]),
+                    dx=deriv[0],
+                    dy=deriv[1],
                     grid=False,
                 )
             )
@@ -1533,6 +1539,8 @@ def _interp2d(
             )(
                 x0[slix],
                 x1[slix],
+                dx=deriv[0],
+                dy=deriv[1],
                 grid=False,
             )
 

--- a/datastock/_class1_interpolate.py
+++ b/datastock/_class1_interpolate.py
@@ -553,6 +553,9 @@ def _check_params(
 
     elif ndim == 2:
 
+        if np.isscalar(deriv):
+            deriv = (int(deriv), int(deriv))
+
         deriv = tuple(_generic_check._check_var_iter(
             deriv, 'deriv',
             default=(0, 0),

--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -140,6 +140,7 @@ def _check_var_iter(
     types=None,
     types_iter=None,
     default=None,
+    size=None,
     allowed=None,
     excluded=None,
     extra_msg=None,
@@ -185,6 +186,15 @@ def _check_var_iter(
             msg = (
                 f"Arg {varname} must be an iterable of types {types_iter}\n"
                 f"Provided: {[type(vv) for vv in var]}"
+            )
+            raise Exception(_complete_extra_msg(msg, extra_msg))
+
+    # check size
+    if size is not None:
+        if len(var) != size:
+            msg = (
+                f"Arg {varname} must be an iterable of len = {size}\n"
+                f"Provided: {len(var)}"
             )
             raise Exception(_complete_extra_msg(msg, extra_msg))
 


### PR DESCRIPTION
Main changes:
----------------
* `interpolate(deriv=...)` now takes:
    - `deriv = int` for 1d bsplines
    - `deriv = [int, int]` for 2d bsplines  

Issues:
-------
Partially fixes, in devel, issue #149

