### PR TITLE
text can move

### DIFF
--- a/datastock/_class2.py
+++ b/datastock/_class2.py
@@ -87,12 +87,18 @@ class DataStock2(DataStock1):
 
         if isinstance(dtype, str):
             dtype = [dtype]
+        lok = [
+            'xdata', 'ydata',
+            'data', 'data.T',
+            'xy', 'alpha',
+            'txt', 'x', 'y', 'position',
+        ]
         dtype = _generic_check._check_var_iter(
             dtype,
             'dtype',
             types=(list, tuple),
             types_iter=str,
-            allowed=['xdata', 'ydata', 'data', 'data.T', 'xy', 'alpha', 'txt']
+            allowed=lok,
         )
         if len(dtype) != nref:
             msg = (

--- a/datastock/_class2_interactivity.py
+++ b/datastock/_class2_interactivity.py
@@ -479,6 +479,15 @@ def get_fupdate(handle=None, dtype=None, norm=None, bstr=None):
             handle.set_alpha(norm(val))
     elif dtype == 'txt':
         func = lambda val, handle=handle, bstr=bstr: handle.set_text(bstr.format(val))
+    elif dtype == 'x':
+        def func(val, handle=handle):
+            handle.set_x(val)
+    elif dtype == 'y':
+        def func(val, handle=handle):
+            handle.set_y(val)
+    elif dtype == 'position':
+        def func(val, handle=handle):
+            handle.set_position(val)
     else:
         msg = f'Unknown mobile dtype: {dtype}'
         raise Exception(msg)


### PR DESCRIPTION
Main changes:
-----------------

* the following 3 addition dtype options are available for mobile definition:
    - `'x'`: calls `text.set_x()`
    - `'y'`: calls `text.set_y()`
    - `'position'`: calls `text.set_position()`

Issues:
-------

Fixes, in devel, issue #158 

Examples:
-----------

Used for moving spectral labels in 

![image](https://github.com/user-attachments/assets/1464b843-4b04-42a7-a6ab-ab312ccc388b)


