### PR TITLE
Issue162 ref vector exclude

### DIFF
--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -617,6 +617,9 @@ class DataStock1(DataStock0):
         quant=None,
         name=None,
         units=None,
+        # exclude from search
+        key_exclude=None,
+        ref_exclude=None,
         # nearest-neighbour interpolation input
         values=None,
         indices=None,
@@ -666,6 +669,9 @@ class DataStock1(DataStock0):
             quant=quant,
             name=name,
             units=units,
+            # exclude from search
+            key_exclude=key_exclude,
+            ref_exclude=ref_exclude,
             # parameters
             values=values,
             indices=indices,

--- a/datastock/_class1.py
+++ b/datastock/_class1.py
@@ -692,6 +692,9 @@ class DataStock1(DataStock0):
         # strategy for choosing common ref vector
         strategy=None,
         strategy_bounds=None,
+        # exclude from search
+        key_exclude=None,
+        ref_exclude=None,
         # values, indices
         values=None,
         indices=None,
@@ -725,6 +728,9 @@ class DataStock1(DataStock0):
             # strategy for choosing common ref vector
             strategy=strategy,
             strategy_bounds=strategy_bounds,
+            # exclude from search
+            key_exclude=key_exclude,
+            ref_exclude=ref_exclude,
             # parameters
             values=values,
             indices=indices,

--- a/datastock/_class1_uniformize.py
+++ b/datastock/_class1_uniformize.py
@@ -43,6 +43,9 @@ def get_ref_vector(
     quant=None,
     name=None,
     units=None,
+    # exclude from search
+    key_exclude=None,
+    ref_exclude=None,
     # parameters
     values=None,
     indices=None,
@@ -52,6 +55,7 @@ def get_ref_vector(
 
     # ----------------
     # check inputs
+    # ----------------
 
     # ind_strict
     ind_strict = _generic_check._check_var(
@@ -82,6 +86,23 @@ def get_ref_vector(
         allowed=lkok,
     )
 
+    # key_exclude
+    if key_exclude is not None:
+        key_exclude = _generic_check._check_var_iter(
+            key_exclude, 'key_exclude',
+            types=(list, tuple),
+            types_iter=str,
+        )
+
+    # ref_exclude
+    if ref_exclude is not None:
+        ref_exclude = _generic_check._check_var_iter(
+            ref_exclude, 'ref_exclude',
+            types=(list, tuple),
+            types_iter=str,
+        )
+
+    # key0 vs ref
     if key0 is None and ref is None:
         msg = "Please provide key0 or ref at least!"
         raise Exception(msg)
@@ -95,6 +116,7 @@ def get_ref_vector(
 
     # ------------------------
     # hasref, hasvect
+    # ------------------------
 
     hasref = None
     if ref is not None and key0 is not None:
@@ -109,8 +131,13 @@ def get_ref_vector(
     elif key0 is not None:
         refok = ddata[key0]['ref']
 
+    # ----------------------
     # identify possible vect
+    # ----------------------
+
     if hasref is not False:
+
+
         lp = [('dim', dim), ('quant', quant), ('name', name), ('units', units)]
         lk_vect = [
             k0 for k0, v0 in ddata.items()
@@ -121,6 +148,8 @@ def get_ref_vector(
                 or (vv is not None and v0[ss] == vv)
                 for ss, vv in lp
             ])
+            and (key_exclude is None or k0 not in key_exclude)
+            and (ref_exclude is None or v0['ref'][0] not in ref_exclude)
         ]
 
         # if key is provided
@@ -161,14 +190,18 @@ def get_ref_vector(
     else:
         hasvect = False
 
+    # -------------------------
     # set hasref if not yet set
+
     if hasvect is False:
         key_vector = None
         if hasref is None:
             hasref = False
             ref = None
 
+    # ----------------------
     # consistency check
+
     assert hasref == (ref is not None)
     assert hasvect == (key_vector is not None)
 
@@ -180,6 +213,7 @@ def get_ref_vector(
 
     # -----------------
     # values vs indices
+    # -----------------
 
     dind = _get_ref_vector_values(
         dref=dref,
@@ -193,7 +227,9 @@ def get_ref_vector(
         indices=indices,
     )
 
+    # -----
     # val
+
     if dind is None:
         if key_vector is not None:
             val = ddata[key_vector]['data']

--- a/datastock/_class1_uniformize.py
+++ b/datastock/_class1_uniformize.py
@@ -88,6 +88,8 @@ def get_ref_vector(
 
     # key_exclude
     if key_exclude is not None:
+        if isinstance(key_exclude, str):
+            key_exclude = [key_exclude]
         key_exclude = _generic_check._check_var_iter(
             key_exclude, 'key_exclude',
             types=(list, tuple),
@@ -96,6 +98,8 @@ def get_ref_vector(
 
     # ref_exclude
     if ref_exclude is not None:
+        if isinstance(ref_exclude, str):
+            ref_exclude = [ref_exclude]
         ref_exclude = _generic_check._check_var_iter(
             ref_exclude, 'ref_exclude',
             types=(list, tuple),
@@ -163,7 +167,7 @@ def get_ref_vector(
         # cases
         if len(lk_vect) == 0:
             if warn is True:
-                msg = "No matching vector found!"
+                msg = f"No vector found for key0 = '{key0}', ref '{ref}'!"
                 warnings.warn(msg)
             hasvect = False
 
@@ -177,15 +181,14 @@ def get_ref_vector(
                 hasref = True
 
         else:
-            if warn is True:
-                msg = (
-                    f"Multiple possible vectors found:\n{lk_vect}\n"
-                    f"\t- key0: {key0}\n"
-                    f"\t- ref: {ref}\n"
-                    f"\t- hasref: {hasref}\n"
-                    f"\t- refok: {refok}\n"
-                )
-                warnings.warn(msg)
+            msg = (
+                f"Multiple possible vectors found:\n{lk_vect}\n"
+                f"\t- key0: {key0}\n"
+                f"\t- ref: {ref}\n"
+                f"\t- hasref: {hasref}\n"
+                f"\t- refok: {refok}\n"
+            )
+            warnings.warn(msg)
             hasvect = False
     else:
         hasvect = False
@@ -493,6 +496,9 @@ def get_ref_vector_common(
     quant=None,
     name=None,
     units=None,
+    # exclude from search
+    key_exclude=None,
+    ref_exclude=None,
     # strategy for choosing common ref vector
     strategy=None,
     strategy_bounds=None,
@@ -558,6 +564,10 @@ def get_ref_vector_common(
             quant=quant,
             name=name,
             units=units,
+            # exclude from search
+            key_exclude=key_exclude,
+            ref_exclude=ref_exclude,
+            # parameters
             values=None,
             indices=None,
         )
@@ -735,6 +745,9 @@ def get_ref_vector_common(
         dkeys=dkeys,
         key_vector=key_vector,
         val=val,
+        # exclude from search
+        key_exclude=key_exclude,
+        ref_exclude=ref_exclude,
         # values, indices
         values=values,
         indices=indices,
@@ -763,6 +776,9 @@ def _get_ref_vector_common_values(
     dkeys=None,
     key_vector=None,
     val=None,
+    # exclude from search
+    key_exclude=None,
+    ref_exclude=None,
     # values, indices
     values=None,
     indices=None,
@@ -791,6 +807,10 @@ def _get_ref_vector_common_values(
                 quant=quant,
                 name=name,
                 units=units,
+                # exclude from search
+                key_exclude=key_exclude,
+                ref_exclude=ref_exclude,
+                # parameters
                 values=values,
                 indices=indices,
             )


### PR DESCRIPTION
Main changes:
-----------------

* `get_ref_vector(warn=True)` now:
      - only ignores when no ref vector is found
      - multiple vectors will still raise warning
* `get_ref_vector(key_exclude=list, ref_exclude=list)` implemented
      - allows to exclude from search vectors or refs that are known to be non-relevant
      - makes search more efficient
* `get_ref_vector_common(key_exclude=list, ref_exclude=list)` implemented
      - same as above


Issues:
-------

Fixes, in devel, issue #162 