### PR TITLE
[#170] Fixed order of default separators

### DIFF
--- a/datastock/_class0.py
+++ b/datastock/_class0.py
@@ -168,7 +168,7 @@ class DataStock0(object):
         return_pfe=False,
     ):
 
-        lsep = ['.', '-', '_', ',', ';', '~', '?']
+        lsep = [';', '&', '?', '#', ',', '~', '.', '-', '_']
         if sep is None:
             for ss in lsep:
                 c0 = (


### PR DESCRIPTION
Main changes:
----------------

Changes order of default `sep` to `[';', '&', '?', '#', ',', '~', '.', '-', '_']`

Issues:
-------

Fixes, in devel, issue #170 

