### PR TITLE
`'units'` are equal whether `str` or `asunits.Unit` when looking for conflicts

### DIFF
--- a/datastock/_class1_check.py
+++ b/datastock/_class1_check.py
@@ -147,7 +147,14 @@ def _check_conflicts(dd=None, dd0=None, dd_name=None, returnas=None):
                     or (
                         not isinstance(v0[kk], np.ndarray)
                         and not scpsp.issparse(v0[kk])
-                        and v0[kk] == dd0[k0][kk]
+                        and (
+                            v0[kk] == dd0[k0][kk]
+                            or (
+                                # asunit.Unit vs str should be the same
+                                kk == 'units'
+                                and str(v0[kk]) == str(dd0[k0][kk])
+                            )
+                        )
                     )
                 )
             )


### PR DESCRIPTION
Main changes:
----------------

* When looking for conflicts, there is now an exception for `'units'`:
    - if one dict has units as `str` 
    - and the other as `asunits.Unit` 
    - but they have the same `str` representation => they are considered equal


Issues:
-------

Fixes, in devel, issue #174 