### PR TITLE
Issue202 `_check_all_broadcastable(**kwdargs)`

### DIFF
--- a/datastock/_generic_check.py
+++ b/datastock/_generic_check.py
@@ -624,13 +624,15 @@ def _check_all_broadcastable(**kwdargs):
                 dfail[k0] = f"Non-compatible shape = {v0.shape} (ii = {ii})"
                 continue
 
+    shapef = tuple(shapef)
+
     # raise Exception if needed
-    if len(dfail) > 1:
+    if len(dfail) > 0:
         lstr = [f"\t- {k0}: {v0}" for k0, v0 in dfail.items()]
         msg = (
             "The following keywords args have non-compatible shape:\n"
             + "\n".join(lstr)
-            + f"Reference shape: {shapef}\n"
+            + f"\nReference shape: {shapef}\n"
         )
         raise Exception(msg)
 

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -14,6 +14,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # datastock-specific
+from .._generic_check import _check_all_broadcastable
 from .._class import DataStock
 from .._saveload import load
 
@@ -227,6 +228,37 @@ class Test01_Instanciate():
 
     def test03_add_obj(self):
         _add_obj(st=self.st, nc=self.nc)
+
+    # ------------------------
+    #   Tools
+    # ------------------------
+
+    def test04_check_all_broadcastable(self):
+        # all scalar
+        dout, shape = _check_all_broadcastable(a=1, b=2)
+
+        # scalar + arrays
+        dout, shape = _check_all_broadcastable(a=1, b=(1, 2, 3))
+
+        # all arrays
+        dout, shape = _check_all_broadcastable(
+            a=(1, 2, 3),
+            b=(1, 2, 3),
+        )
+
+        # all arrays - 2d
+        dout, shape = _check_all_broadcastable(
+            a=np.r_[1, 2, 3][:, None],
+            b=np.r_[10, 20][None, :],
+        )
+
+        # check flag
+        err = False
+        try:
+            dout, shape = _check_all_broadcastable(a=(1, 2), b=(1, 2, 3))
+        except Exception as err:
+            err = True
+        assert err is True
 
 
 #######################################################

--- a/datastock/tests/test_01_DataStock.py
+++ b/datastock/tests/test_01_DataStock.py
@@ -256,8 +256,9 @@ class Test01_Instanciate():
         err = False
         try:
             dout, shape = _check_all_broadcastable(a=(1, 2), b=(1, 2, 3))
-        except Exception as err:
+        except Exception:
             err = True
+
         assert err is True
 
 


### PR DESCRIPTION
Main changes:
----------------

* `ds._generic_check._check_all_broadcastable(**kwdargs)` implemented
    - return `dout, shape`, where `shape` is `None` if all are scalar
    - check all provided `kwdargs` are broadcastable against each-other as is (without dimension extension)


Issues:
-------

Fixes, in devel, issue #202 